### PR TITLE
Link to aut-docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![LICENSE](https://img.shields.io/badge/license-Apache-blue.svg?style=flat-square)](./LICENSE)
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 
-The Archives Unleashed Toolkit is an open-source platform for analyzing web archives. Tight integration with Hadoop provides powerful tools for analytics and data processing via Apache Spark.
+The Archives Unleashed Toolkit is an open-source platform for analyzing web archives. Tight integration with Hadoop provides powerful tools for analytics and data processing via Apache Spark. [Our full documentation can be found here](http://docs.archivesunleashed.io/).
 
 ## Getting Started
 
@@ -28,6 +28,8 @@ For the impatient, to skip tests:
 ```
 $ mvn clean install -DskipTests
 ```
+
+Once built or downloaded, [you can follow the basic set of tutorials here](http://docs.archivesunleashed.io/).
 
 The Archives Unleashed Toolkit is built against CDH 5.7.1:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![LICENSE](https://img.shields.io/badge/license-Apache-blue.svg?style=flat-square)](./LICENSE)
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 
-The Archives Unleashed Toolkit is an open-source platform for analyzing web archives. Tight integration with Hadoop provides powerful tools for analytics and data processing via Apache Spark. [Our full documentation can be found here](http://docs.archivesunleashed.io/).
+The Archives Unleashed Toolkit is an open-source platform for analyzing web archives. Tight integration with Hadoop provides powerful tools for analytics and data processing via Apache Spark. [Our full documentation can be found at <http://docs.archivesunleashed.io/>.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![LICENSE](https://img.shields.io/badge/license-Apache-blue.svg?style=flat-square)](./LICENSE)
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 
-The Archives Unleashed Toolkit is an open-source platform for analyzing web archives. Tight integration with Hadoop provides powerful tools for analytics and data processing via Apache Spark. [Our full documentation can be found at <http://docs.archivesunleashed.io/>.
+The Archives Unleashed Toolkit is an open-source platform for analyzing web archives. Tight integration with Hadoop provides powerful tools for analytics and data processing via Apache Spark. Our full documentation can be found at <http://docs.archivesunleashed.io/>.
 
 ## Getting Started
 


### PR DESCRIPTION
I realized that I kept having to dig out the aut-docs URL, so now that it's been playtested it's ready to be live. 

I added in two links, one in the header, and one after the build instructions. Without documentation on how to use it, folks might not realize what they can do with aut.