### PR TITLE
Improve coverage for TweetUtils

### DIFF
--- a/src/main/scala/io/archivesunleashed/spark/matchbox/TweetUtils.scala
+++ b/src/main/scala/io/archivesunleashed/spark/matchbox/TweetUtils.scala
@@ -28,7 +28,7 @@ object TweetUtils {
     def lang: String = try { (tweet \ "lang").extract[String] } catch { case e: Exception => null}
 
     def username(): String = try { (tweet \ "user" \ "screen_name").extract[String] } catch { case e: Exception => null}
-    def isVerifiedUser(): Boolean = try { (tweet \ "user" \ "screen_name").extract[String] == "false" } catch { case e: Exception => false}
+    def isVerifiedUser(): Boolean = try { (tweet \ "user" \ "verified").extract[Boolean] } catch { case e: Exception => false}
 
     def followerCount: Int = try { (tweet \ "user" \ "followers_count").extract[Int] } catch { case e: Exception => 0}
     def friendCount: Int = try { (tweet \ "user" \ "friends_count").extract[Int] } catch { case e: Exception => 0}

--- a/src/test/scala/io/archivesunleashed/spark/matchbox/TweetUtilsTest.scala
+++ b/src/test/scala/io/archivesunleashed/spark/matchbox/TweetUtilsTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Archives Unleashed Toolkit (AUT):
+ * An open-source platform for analyzing web archives.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.archivesunleashed.spark.matchbox
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.json4s.JsonAST._
+import TweetUtils._
+
+@RunWith(classOf[JUnitRunner])
+class TweetUtilsTest extends FunSuite {
+  test("remove prefix") {
+    var tweet:org.json4s.JValue = parse("""{"id_str":"123",
+      "created_at":"20150702",
+      "text": "some text",
+      "lang": "en",
+      "user": {
+      "screen_name": "twitteruser",
+      "verified": true,
+      "followers_count": 45,
+      "friends_count": 758}}""")
+
+    assert(tweet.id() == "123")
+    assert(tweet.createdAt() == "20150702")
+    assert(tweet.text() == "some text")
+    assert(tweet.lang == "en")
+    assert(tweet.username() == "twitteruser")
+    assert(tweet.isVerifiedUser() == true)
+    assert(tweet.followerCount == 45)
+    assert(tweet.friendCount == 758)
+  }
+
+  test("errors") {
+    var tweet:org.json4s.JValue = parse("""{"id_str": null,
+      "created_at":null,
+      "text": null,
+      "lang": null,
+      "user": {
+      "screen_name": null,
+      "verified" : null,
+      "followers_count": null,
+      "friends_count": null}}""")
+
+      assert(tweet.id() == null)
+      assert(tweet.createdAt() == null)
+      assert(tweet.text() == null)
+      assert(tweet.lang == null)
+      assert(tweet.username() == null)
+      assert(tweet.isVerifiedUser() == false)
+      assert(tweet.followerCount == 0)
+      assert(tweet.friendCount == 0)
+  }
+}


### PR DESCRIPTION
**Add Test for TweetUtils**

* * *

**GitHub issue(s)**:

If you are responding to an issue, please mention their numbers below.

#54 

# What does this Pull Request do?

A brief description of what the intended result of the Pull Request (PR) will be, what problem it solves, technical details, and any possible side effects.

Example:
* Increases test coverage
* Fixes TweetUtil to accept verified user input from a Twitter JSON stream

# How should this be tested?

Codecov and Travis should work to cover test.
However, trying out an export from a tweet sample would confirm it works properly.

# Additional Notes:

Any additional information that you think would be helpful when reviewing this PR.

TweetUtils has a "isVerifiedUser()" function that was merely double-checking for user.  I switched this to accept a value for a "verified" (in Twitter's terms) user.

# Interested parties

@ruebot 

Thanks in advance for your help with the Archives Unleashed Toolkit!
