### PR TITLE
Adding getCrawlYear in ArchiveRecords, resolves #104

### DIFF
--- a/src/main/scala/io/archivesunleashed/spark/archive/io/ArcRecord.scala
+++ b/src/main/scala/io/archivesunleashed/spark/archive/io/ArcRecord.scala
@@ -27,6 +27,8 @@ class ArcRecord(r: SerializableWritable[ArcRecordWritable]) extends ArchiveRecor
 
   val getCrawlMonth: String = ExtractDate(r.t.getRecord.getMetaData.getDate, DateComponent.YYYYMM)
 
+  val getCrawlYear: String = ExtractDate(r.t.getRecord.getMetaData.getDate, DateComponent.YYYY)
+
   val getMimeType: String = r.t.getRecord.getMetaData.getMimetype
 
   val getUrl: String = r.t.getRecord.getMetaData.getUrl

--- a/src/main/scala/io/archivesunleashed/spark/archive/io/ArchiveRecord.scala
+++ b/src/main/scala/io/archivesunleashed/spark/archive/io/ArchiveRecord.scala
@@ -21,6 +21,8 @@ trait ArchiveRecord extends Serializable {
 
   val getCrawlMonth: String
 
+  val getCrawlYear: String
+
   val getUrl: String
 
   val getDomain: String

--- a/src/main/scala/io/archivesunleashed/spark/archive/io/GenericArchiveRecord.scala
+++ b/src/main/scala/io/archivesunleashed/spark/archive/io/GenericArchiveRecord.scala
@@ -57,6 +57,14 @@ class GenericArchiveRecord(r: SerializableWritable[GenericArchiveRecordWritable]
     }
   }
 
+  val getCrawlYear: String = {
+    if (r.t.getFormat == ArchiveFormat.ARC) {
+      ExtractDate(arcRecord.getMetaData.getDate, DateComponent.YYYY)
+    } else {
+      ExtractDate(ArchiveUtils.get14DigitDate(ISO8601.parse(warcRecord.getHeader.getDate)), DateComponent.YYYY)
+    }
+  }
+
   val getContentBytes: Array[Byte] = {
     if (r.t.getFormat == ArchiveFormat.ARC) {
       ArcRecordUtils.getBodyContent(arcRecord)

--- a/src/main/scala/io/archivesunleashed/spark/archive/io/WarcRecord.scala
+++ b/src/main/scala/io/archivesunleashed/spark/archive/io/WarcRecord.scala
@@ -32,6 +32,8 @@ class WarcRecord(r: SerializableWritable[WarcRecordWritable]) extends ArchiveRec
 
   val getCrawlMonth: String = ExtractDate(ArchiveUtils.get14DigitDate(ISO8601.parse(r.t.getRecord.getHeader.getDate)), DateComponent.YYYYMM)
 
+  val getCrawlYear: String = ExtractDate(ArchiveUtils.get14DigitDate(ISO8601.parse(r.t.getRecord.getHeader.getDate)), DateComponent.YYYY)
+
   val getContentBytes: Array[Byte] = WarcRecordUtils.getContent(r.t.getRecord)
 
   val getContentString: String = new String(getContentBytes)


### PR DESCRIPTION
**GitHub issue(s)**:

* #104 

# What does this Pull Request do?

This pull request:
* Adds getCrawlYear to accompany getCrawlMonth and getCrawlDate
* No features removed
* Has been tested on scripts

# How should this be tested?

This is not fixing a bug but adding a new feature. Usage example can be seen in the #104 ticket, and will be added to documentation. I don't think it will have a real effect on code coverage, but we will see (getCrawlMonth is also not part of unit tests right now, I think).

# Additional Notes:

* This will require updating of <http://docs.archivesunleashed.io/Spark-Analysis-of-Site-Link-Structure/>.