### PR TITLE
Exclude old version of Hadoop. Resolves #118.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -453,6 +453,12 @@
       <groupId>org.netpreserve.commons</groupId>
       <artifactId>webarchive-commons</artifactId>
       <version>1.1.8</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>edu.stanford.nlp</groupId>


### PR DESCRIPTION
**GitHub issue(s)**: #118

# What does this Pull Request do?

Excludes old version of Hadoop that was being pulled in with webarchive-commons.

# How should this be tested?

TravisCI should take care of it.

# Additional Notes:

While I'm in here, let me know if I should get out the chainsaw:

```
$ mvn dependency:tree -Ddetail=true
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building Archives Unleashed Toolkit 0.11.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ aut ---
[INFO] io.archivesunleashed:aut:jar:0.11.1-SNAPSHOT
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.scalatest:scalatest_2.11:jar:3.0.1:test
[INFO] |  +- org.scalactic:scalactic_2.11:jar:3.0.1:test
[INFO] |  +- org.scala-lang:scala-reflect:jar:2.11.8:compile
[INFO] |  +- org.scala-lang.modules:scala-xml_2.11:jar:1.0.5:compile
[INFO] |  \- org.scala-lang.modules:scala-parser-combinators_2.11:jar:1.0.4:compile
[INFO] +- org.scala-lang:scala-parser-combinators:jar:2.11.0-M4:compile
[INFO] +- org.scala-lang:scala-library:jar:2.11.8:compile
[INFO] +- com.chuusai:shapeless_2.11:jar:2.3.2:compile
[INFO] |  \- org.typelevel:macro-compat_2.11:jar:1.1.1:compile
[INFO] +- org.apache.spark:spark-core_2.11:jar:2.1.1:compile
[INFO] |  +- org.apache.avro:avro-mapred:jar:hadoop2:1.7.7:compile
[INFO] |  |  +- org.apache.avro:avro-ipc:jar:1.7.7:compile
[INFO] |  |  |  \- org.apache.avro:avro:jar:1.7.7:compile
[INFO] |  |  \- org.apache.avro:avro-ipc:jar:tests:1.7.7:compile
[INFO] |  +- com.twitter:chill_2.11:jar:0.8.0:compile
[INFO] |  |  \- com.esotericsoftware:kryo-shaded:jar:3.0.3:compile
[INFO] |  |     +- com.esotericsoftware:minlog:jar:1.3.0:compile
[INFO] |  |     \- org.objenesis:objenesis:jar:2.1:compile
[INFO] |  +- com.twitter:chill-java:jar:0.8.0:compile
[INFO] |  +- org.apache.xbean:xbean-asm5-shaded:jar:4.4:compile
[INFO] |  +- org.apache.hadoop:hadoop-client:jar:2.2.0:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-common:jar:2.2.0:compile
[INFO] |  |  |  +- commons-cli:commons-cli:jar:1.2:compile
[INFO] |  |  |  +- org.apache.commons:commons-math:jar:2.1:compile
[INFO] |  |  |  +- xmlenc:xmlenc:jar:0.52:compile
[INFO] |  |  |  \- org.apache.hadoop:hadoop-auth:jar:2.2.0:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-hdfs:jar:2.2.0:compile
[INFO] |  |  |  \- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-mapreduce-client-app:jar:2.2.0:compile
[INFO] |  |  |  +- org.apache.hadoop:hadoop-mapreduce-client-common:jar:2.2.0:compile
[INFO] |  |  |  |  +- org.apache.hadoop:hadoop-yarn-client:jar:2.2.0:compile
[INFO] |  |  |  |  |  \- com.google.inject:guice:jar:3.0:compile
[INFO] |  |  |  |  |     +- javax.inject:javax.inject:jar:1:compile
[INFO] |  |  |  |  |     \- aopalliance:aopalliance:jar:1.0:compile
[INFO] |  |  |  |  \- org.apache.hadoop:hadoop-yarn-server-common:jar:2.2.0:compile
[INFO] |  |  |  \- org.apache.hadoop:hadoop-mapreduce-client-shuffle:jar:2.2.0:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-yarn-api:jar:2.2.0:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-mapreduce-client-core:jar:2.2.0:compile
[INFO] |  |  |  \- org.apache.hadoop:hadoop-yarn-common:jar:2.2.0:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-mapreduce-client-jobclient:jar:2.2.0:compile
[INFO] |  |  \- org.apache.hadoop:hadoop-annotations:jar:2.2.0:compile
[INFO] |  +- org.apache.spark:spark-launcher_2.11:jar:2.1.1:compile
[INFO] |  +- org.apache.spark:spark-network-common_2.11:jar:2.1.1:compile
[INFO] |  |  +- org.fusesource.leveldbjni:leveldbjni-all:jar:1.8:compile
[INFO] |  |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.6.5:compile
[INFO] |  +- org.apache.spark:spark-network-shuffle_2.11:jar:2.1.1:compile
[INFO] |  +- org.apache.spark:spark-unsafe_2.11:jar:2.1.1:compile
[INFO] |  +- org.apache.curator:curator-recipes:jar:2.4.0:compile
[INFO] |  |  +- org.apache.curator:curator-framework:jar:2.4.0:compile
[INFO] |  |  |  \- org.apache.curator:curator-client:jar:2.4.0:compile
[INFO] |  |  \- org.apache.zookeeper:zookeeper:jar:3.4.5:compile
[INFO] |  +- com.google.code.findbugs:jsr305:jar:1.3.9:compile
[INFO] |  +- log4j:log4j:jar:1.2.17:compile
[INFO] |  +- org.slf4j:slf4j-log4j12:jar:1.7.16:compile
[INFO] |  +- com.ning:compress-lzf:jar:1.0.3:compile
[INFO] |  +- net.jpountz.lz4:lz4:jar:1.3.0:compile
[INFO] |  +- org.roaringbitmap:RoaringBitmap:jar:0.5.11:compile
[INFO] |  +- org.json4s:json4s-jackson_2.11:jar:3.2.11:compile
[INFO] |  |  \- org.json4s:json4s-core_2.11:jar:3.2.11:compile
[INFO] |  |     +- org.json4s:json4s-ast_2.11:jar:3.2.11:compile
[INFO] |  |     +- com.thoughtworks.paranamer:paranamer:jar:2.6:compile
[INFO] |  |     \- org.scala-lang:scalap:jar:2.11.0:compile
[INFO] |  |        \- org.scala-lang:scala-compiler:jar:2.11.0:compile
[INFO] |  +- org.glassfish.jersey.core:jersey-client:jar:2.22.2:compile
[INFO] |  |  +- javax.ws.rs:javax.ws.rs-api:jar:2.0.1:compile
[INFO] |  |  +- org.glassfish.hk2:hk2-api:jar:2.4.0-b34:compile
[INFO] |  |  |  +- org.glassfish.hk2:hk2-utils:jar:2.4.0-b34:compile
[INFO] |  |  |  \- org.glassfish.hk2.external:aopalliance-repackaged:jar:2.4.0-b34:compile
[INFO] |  |  +- org.glassfish.hk2.external:javax.inject:jar:2.4.0-b34:compile
[INFO] |  |  \- org.glassfish.hk2:hk2-locator:jar:2.4.0-b34:compile
[INFO] |  |     \- org.javassist:javassist:jar:3.18.1-GA:compile
[INFO] |  +- org.glassfish.jersey.core:jersey-common:jar:2.22.2:compile
[INFO] |  |  +- javax.annotation:javax.annotation-api:jar:1.2:compile
[INFO] |  |  +- org.glassfish.jersey.bundles.repackaged:jersey-guava:jar:2.22.2:compile
[INFO] |  |  \- org.glassfish.hk2:osgi-resource-locator:jar:1.0.1:compile
[INFO] |  +- org.glassfish.jersey.core:jersey-server:jar:2.22.2:compile
[INFO] |  |  +- org.glassfish.jersey.media:jersey-media-jaxb:jar:2.22.2:compile
[INFO] |  |  \- javax.validation:validation-api:jar:1.1.0.Final:compile
[INFO] |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:2.22.2:compile
[INFO] |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.22.2:compile
[INFO] |  +- io.netty:netty-all:jar:4.0.42.Final:compile
[INFO] |  +- io.netty:netty:jar:3.8.0.Final:compile
[INFO] |  +- com.clearspring.analytics:stream:jar:2.7.0:compile
[INFO] |  +- io.dropwizard.metrics:metrics-core:jar:3.1.2:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jvm:jar:3.1.2:compile
[INFO] |  +- io.dropwizard.metrics:metrics-json:jar:3.1.2:compile
[INFO] |  +- io.dropwizard.metrics:metrics-graphite:jar:3.1.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.6.5:compile
[INFO] |  +- com.fasterxml.jackson.module:jackson-module-scala_2.11:jar:2.6.5:compile
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-paranamer:jar:2.6.5:compile
[INFO] |  +- org.apache.ivy:ivy:jar:2.4.0:compile
[INFO] |  +- oro:oro:jar:2.0.8:compile
[INFO] |  +- net.razorvine:pyrolite:jar:4.13:compile
[INFO] |  +- net.sf.py4j:py4j:jar:0.10.4:compile
[INFO] |  +- org.apache.spark:spark-tags_2.11:jar:2.1.1:compile
[INFO] |  +- org.apache.commons:commons-crypto:jar:1.0.0:compile
[INFO] |  \- org.spark-project.spark:unused:jar:1.0.0:compile
[INFO] +- org.apache.spark:spark-graphx_2.11:jar:2.1.1:compile
[INFO] |  +- org.apache.spark:spark-mllib-local_2.11:jar:2.1.1:compile
[INFO] |  |  \- org.scalanlp:breeze_2.11:jar:0.12:compile
[INFO] |  |     +- org.scalanlp:breeze-macros_2.11:jar:0.12:compile
[INFO] |  |     +- net.sf.opencsv:opencsv:jar:2.3:compile
[INFO] |  |     +- com.github.rwl:jtransforms:jar:2.4.0:compile
[INFO] |  |     \- org.spire-math:spire_2.11:jar:0.7.4:compile
[INFO] |  |        \- org.spire-math:spire-macros_2.11:jar:0.7.4:compile
[INFO] |  +- com.github.fommil.netlib:core:jar:1.1.2:compile
[INFO] |  \- net.sourceforge.f2j:arpack_combined_all:jar:0.1:compile
[INFO] +- com.google.guava:guava:jar:23.0:compile
[INFO] |  +- com.google.errorprone:error_prone_annotations:jar:2.0.18:compile
[INFO] |  +- com.google.j2objc:j2objc-annotations:jar:1.1:compile
[INFO] |  \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.14:compile
[INFO] +- org.xerial.snappy:snappy-java:jar:1.1.4:compile
[INFO] +- org.jsoup:jsoup:jar:1.11.1:compile
[INFO] +- org.netpreserve.commons:webarchive-commons:jar:1.1.8:compile
[INFO] |  +- org.json:json:jar:20131018:compile
[INFO] |  +- org.htmlparser:htmlparser:jar:1.6:compile
[INFO] |  +- com.googlecode.juniversalchardet:juniversalchardet:jar:1.0.3:compile
[INFO] |  +- commons-httpclient:commons-httpclient:jar:3.1:compile
[INFO] |  +- commons-lang:commons-lang:jar:2.5:compile
[INFO] |  +- commons-io:commons-io:jar:2.4:compile
[INFO] |  +- org.gnu.inet:libidn:jar:1.15:compile
[INFO] |  +- it.unimi.dsi:dsiutils:jar:2.0.12:compile
[INFO] |  |  +- it.unimi.dsi:fastutil:jar:6.5.2:compile
[INFO] |  |  +- com.martiansoftware:jsap:jar:2.1:compile
[INFO] |  |  +- commons-configuration:commons-configuration:jar:1.8:compile
[INFO] |  |  \- commons-collections:commons-collections:jar:3.2.1:compile
[INFO] |  \- org.apache.httpcomponents:httpcore:jar:4.3:compile
[INFO] +- edu.stanford.nlp:stanford-corenlp:jar:3.8.0:compile
[INFO] |  +- com.apple:AppleJavaExtensions:jar:1.4:compile
[INFO] |  +- de.jollyday:jollyday:jar:0.4.9:compile
[INFO] |  |  \- javax.xml.bind:jaxb-api:jar:2.2.7:compile
[INFO] |  +- org.apache.lucene:lucene-queryparser:jar:4.10.3:compile
[INFO] |  |  \- org.apache.lucene:lucene-sandbox:jar:4.10.3:compile
[INFO] |  +- org.apache.lucene:lucene-analyzers-common:jar:4.10.3:compile
[INFO] |  +- org.apache.lucene:lucene-queries:jar:4.10.3:compile
[INFO] |  +- org.apache.lucene:lucene-core:jar:4.10.3:compile
[INFO] |  +- com.io7m.xom:xom:jar:1.2.10:compile
[INFO] |  |  \- xalan:xalan:jar:2.7.0:compile
[INFO] |  +- com.googlecode.efficient-java-matrix-library:ejml:jar:0.23:compile
[INFO] |  +- org.glassfish:javax.json:jar:1.0.4:compile
[INFO] |  \- com.google.protobuf:protobuf-java:jar:3.2.0:compile
[INFO] +- org.apache.tika:tika-core:jar:1.16:compile
[INFO] +- org.apache.tika:tika-parsers:jar:1.16:compile
[INFO] |  +- org.gagravarr:vorbis-java-tika:jar:0.8:compile
[INFO] |  +- com.healthmarketscience.jackcess:jackcess:jar:2.1.8:compile
[INFO] |  +- com.healthmarketscience.jackcess:jackcess-encrypt:jar:2.1.2:compile
[INFO] |  +- org.tallison:jmatio:jar:1.2:compile
[INFO] |  +- org.apache.james:apache-mime4j-core:jar:0.8.1:compile
[INFO] |  +- org.apache.james:apache-mime4j-dom:jar:0.8.1:compile
[INFO] |  +- org.apache.commons:commons-compress:jar:1.14:compile
[INFO] |  +- org.tukaani:xz:jar:1.6:compile
[INFO] |  +- commons-codec:commons-codec:jar:1.10:compile
[INFO] |  +- org.apache.pdfbox:pdfbox:jar:2.0.6:compile
[INFO] |  |  \- org.apache.pdfbox:fontbox:jar:2.0.6:compile
[INFO] |  +- org.apache.pdfbox:pdfbox-tools:jar:2.0.6:compile
[INFO] |  |  \- org.apache.pdfbox:pdfbox-debugger:jar:2.0.6:compile
[INFO] |  +- org.apache.pdfbox:jempbox:jar:1.8.13:compile
[INFO] |  +- org.bouncycastle:bcmail-jdk15on:jar:1.54:compile
[INFO] |  |  \- org.bouncycastle:bcpkix-jdk15on:jar:1.54:compile
[INFO] |  +- org.bouncycastle:bcprov-jdk15on:jar:1.54:compile
[INFO] |  +- org.apache.poi:poi:jar:3.17-beta1:compile
[INFO] |  |  \- org.apache.commons:commons-collections4:jar:4.1:compile
[INFO] |  +- org.apache.poi:poi-scratchpad:jar:3.17-beta1:compile
[INFO] |  +- org.apache.poi:poi-ooxml:jar:3.17-beta1:compile
[INFO] |  |  +- org.apache.poi:poi-ooxml-schemas:jar:3.17-beta1:compile
[INFO] |  |  |  \- org.apache.xmlbeans:xmlbeans:jar:2.6.0:compile
[INFO] |  |  \- com.github.virtuald:curvesapi:jar:1.04:compile
[INFO] |  +- org.ccil.cowan.tagsoup:tagsoup:jar:1.2.1:compile
[INFO] |  +- org.ow2.asm:asm:jar:5.0.4:compile
[INFO] |  +- com.googlecode.mp4parser:isoparser:jar:1.1.18:compile
[INFO] |  +- com.drewnoakes:metadata-extractor:jar:2.9.1:compile
[INFO] |  |  \- com.adobe.xmp:xmpcore:jar:5.1.2:compile
[INFO] |  +- de.l3s.boilerpipe:boilerpipe:jar:1.1.0:compile
[INFO] |  +- com.rometools:rome:jar:1.5.1:compile
[INFO] |  |  \- com.rometools:rome-utils:jar:1.5.1:compile
[INFO] |  +- org.gagravarr:vorbis-java-core:jar:0.8:compile
[INFO] |  +- org.codelibs:jhighlight:jar:1.0.2:compile
[INFO] |  +- com.pff:java-libpst:jar:0.8.1:compile
[INFO] |  +- com.github.junrar:junrar:jar:0.7:compile
[INFO] |  |  \- org.apache.commons:commons-vfs2:jar:2.0:compile
[INFO] |  |     +- org.apache.maven.scm:maven-scm-api:jar:1.4:compile
[INFO] |  |     |  \- org.codehaus.plexus:plexus-utils:jar:1.5.6:compile
[INFO] |  |     \- org.apache.maven.scm:maven-scm-provider-svnexe:jar:1.4:compile
[INFO] |  |        +- org.apache.maven.scm:maven-scm-provider-svn-commons:jar:1.4:compile
[INFO] |  |        \- regexp:regexp:jar:1.3:compile
[INFO] |  +- org.apache.cxf:cxf-rt-rs-client:jar:3.0.12:compile
[INFO] |  |  +- org.apache.cxf:cxf-rt-transports-http:jar:3.0.12:compile
[INFO] |  |  +- org.apache.cxf:cxf-core:jar:3.0.12:compile
[INFO] |  |  |  +- org.codehaus.woodstox:woodstox-core-asl:jar:4.4.1:compile
[INFO] |  |  |  |  \- org.codehaus.woodstox:stax2-api:jar:3.1.4:compile
[INFO] |  |  |  \- org.apache.ws.xmlschema:xmlschema-core:jar:2.2.1:compile
[INFO] |  |  \- org.apache.cxf:cxf-rt-frontend-jaxrs:jar:3.0.12:compile
[INFO] |  +- org.apache.commons:commons-exec:jar:1.3:compile
[INFO] |  +- org.apache.opennlp:opennlp-tools:jar:1.6.0:compile
[INFO] |  +- com.googlecode.json-simple:json-simple:jar:1.1.1:compile
[INFO] |  +- com.tdunning:json:jar:1.8:compile
[INFO] |  +- com.google.code.gson:gson:jar:2.8.1:compile
[INFO] |  +- edu.ucar:netcdf4:jar:4.5.5:compile
[INFO] |  |  +- net.jcip:jcip-annotations:jar:1.0:compile
[INFO] |  |  \- net.java.dev.jna:jna:jar:4.1.0:compile
[INFO] |  +- edu.ucar:grib:jar:4.5.5:compile
[INFO] |  |  +- org.jdom:jdom2:jar:2.0.4:compile
[INFO] |  |  \- org.itadaki:bzip2:jar:0.9.1:compile
[INFO] |  +- edu.ucar:cdm:jar:4.5.5:compile
[INFO] |  |  +- edu.ucar:udunits:jar:4.5.5:compile
[INFO] |  |  +- org.quartz-scheduler:quartz:jar:2.2.0:compile
[INFO] |  |  |  \- c3p0:c3p0:jar:0.9.1.1:compile
[INFO] |  |  +- net.sf.ehcache:ehcache-core:jar:2.6.2:compile
[INFO] |  |  \- com.beust:jcommander:jar:1.35:compile
[INFO] |  +- edu.ucar:httpservices:jar:4.5.5:compile
[INFO] |  |  +- org.apache.httpcomponents:httpclient:jar:4.2.6:compile
[INFO] |  |  \- org.apache.httpcomponents:httpmime:jar:4.2.6:compile
[INFO] |  +- org.apache.commons:commons-csv:jar:1.0:compile
[INFO] |  +- org.apache.sis.core:sis-utility:jar:0.6:compile
[INFO] |  +- org.apache.sis.storage:sis-netcdf:jar:0.6:compile
[INFO] |  |  +- org.apache.sis.storage:sis-storage:jar:0.6:compile
[INFO] |  |  \- org.apache.sis.core:sis-referencing:jar:0.6:compile
[INFO] |  +- org.apache.sis.core:sis-metadata:jar:0.6:compile
[INFO] |  +- org.opengis:geoapi:jar:3.0.0:compile
[INFO] |  |  \- javax.measure:jsr-275:jar:0.9.3:compile
[INFO] |  +- edu.usc.ir:sentiment-analysis-parser:jar:0.1:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.8.1:compile
[INFO] +- com.syncthemall:boilerpipe:jar:1.2.2:compile
[INFO] |  \- net.sourceforge.nekohtml:nekohtml:jar:1.9.20:compile
[INFO] +- xerces:xercesImpl:jar:2.11.0:compile
[INFO] |  \- xml-apis:xml-apis:jar:1.4.01:compile
[INFO] +- tl.lin:lintools-datatypes:jar:1.0.0:compile
[INFO] +- joda-time:joda-time:jar:2.2:compile
[INFO] +- org.apache.commons:commons-math3:jar:3.1.1:compile
[INFO] +- net.java.dev.jets3t:jets3t:jar:0.6.1:compile
[INFO] +- org.codehaus.jackson:jackson-mapper-asl:jar:1.5.2:compile
[INFO] |  \- org.codehaus.jackson:jackson-core-asl:jar:1.5.2:compile
[INFO] +- commons-net:commons-net:jar:1.4.1:compile
[INFO] +- org.apache.commons:commons-lang3:jar:3.3.1:compile
[INFO] +- commons-logging:commons-logging:jar:1.1.3:compile
[INFO] +- org.slf4j:jcl-over-slf4j:jar:1.7.24:compile
[INFO] +- org.slf4j:jul-to-slf4j:jar:1.7.24:compile
[INFO] +- org.slf4j:slf4j-api:jar:1.7.24:compile
[INFO] \- javax.servlet:javax.servlet-api:jar:3.0.1:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```