### PR TITLE
Pin everything to Scala 2.11.8; Resolves #125.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,6 +423,37 @@
       <groupId>com.chuusai</groupId>
       <artifactId>shapeless_2.11</artifactId>
       <version>2.3.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.typelevel</groupId>
+          <artifactId>macro-compat_2.11</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>chill_2.11</artifactId>
+      <version>0.8.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.json4s</groupId>
+      <artifactId>json4s-jackson_2.11</artifactId>
+      <version>3.5.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-parser-combinators_2.11</artifactId>
+      <version>1.0.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-scala_2.11</artifactId>
+      <version>2.8.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scalanlp</groupId>
+      <artifactId>breeze_2.11</artifactId>
+      <version>0.13.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
**GitHub issue(s)**: #125

# What does this Pull Request do?

Pins our dependencies to Scala 2.11.8, which is what we declare in our `pom.xml`.

# How should this be tested?

The build process should show something along the lines of:

```
[INFO] --- maven-scala-plugin:2.15.2:compile (default) @ aut ---
[INFO] Checking for multiple versions of scala
[INFO] includes = [**/*.java,**/*.scala,]
[INFO] excludes = []
[INFO] /home/nruest/git/aut/src/main/java:-1: info: compiling
[INFO] /home/nruest/git/aut/src/main/scala:-1: info: compiling
```

You should *not* see the warning in #125.

Reading the TravisCI build output should be sufficient. I'll toss a link in here to it after it builds.