### PR TITLE
Downgrade Tika to 1.12. Resolves #126.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -499,12 +499,12 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
-      <version>1.16</version>
+      <version>1.12</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
-      <version>1.16</version>
+      <version>1.12</version>
     </dependency>
     <dependency>  <!-- needed for running boilerpipe, but will compile without -->
       <groupId>com.syncthemall</groupId>


### PR DESCRIPTION
**GitHub issue(s)**: 126

# What does this Pull Request do?

Moves us down to Tika 1.12. [1.13](https://tika.apache.org/1.13/)+ deprecates how we `DetectLanguage`.

[Enhancement ticket](https://github.com/archivesunleashed/aut/issues/131) for this. We can get to it when we can.

# How should this be tested?

Checkout the TravisCI build log and make sure you don't see the deprecation notice we were seeing in #126.
