### PR TITLE
Use correct import for WARCConstants; Resolves #127.

### DIFF
--- a/src/main/java/io/archivesunleashed/data/WarcRecordUtils.java
+++ b/src/main/java/io/archivesunleashed/data/WarcRecordUtils.java
@@ -29,7 +29,7 @@ import org.apache.commons.httpclient.HttpParser;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.log4j.Logger;
-import org.archive.io.warc.WARCConstants;
+import org.archive.format.warc.WARCConstants;
 import org.archive.io.warc.WARCReader;
 import org.archive.io.warc.WARCReaderFactory;
 import org.archive.io.warc.WARCRecord;


### PR DESCRIPTION
**GitHub issue(s)**: #127

# What does this Pull Request do?

Don't use the deprecated `WARCConstants`.

# How should this be tested?

Checkout to TravisCI build output, and the deprecation warning in #127 should be gone.