### PR TITLE
Suppresses error handling for ARCs w/ 76 character header difference

### DIFF
--- a/src/main/java/io/archivesunleashed/data/ArcRecordUtils.java
+++ b/src/main/java/io/archivesunleashed/data/ArcRecordUtils.java
@@ -34,8 +34,13 @@ import org.archive.io.arc.ARCRecordMetaData;
  * Utilities for working with {@code ARCRecord}s (from archive.org APIs).
  */
 public final class ArcRecordUtils {
-
   /**
+  * Due to ARC header differences, until we merge code to reflect new
+  * webarchive-discovery version, a consistant difference of 76 bytes
+  * in ARC files is expected.
+  */
+  public static final long HEADER_DIFF = 76;
+   /**
    * Utility classes should not have a public or default constructor.
    */
   private ArcRecordUtils() {
@@ -81,7 +86,7 @@ public final class ArcRecordUtils {
     long recordLength = meta.getLength();
     long len = IOUtils.copyLarge(new BoundedInputStream(record, recordLength),
             dout);
-    if (len != recordLength) {
+    if (len != recordLength + HEADER_DIFF) {
       LOG.error("Read " + len + " bytes but expected " + recordLength
               + " bytes. Continuing...");
     }
@@ -142,9 +147,10 @@ public final class ArcRecordUtils {
 
     BoundedInputStream bis = new BoundedInputStream(is, recordLength);
     byte[] rawContents = IOUtils.toByteArray(bis);
-    if (enforceLength && rawContents.length != recordLength) {
+    if (!(rawContents.length == recordLength - HEADER_DIFF
+          || rawContents.length == recordLength)) {
       LOG.error("Read " + rawContents.length + " bytes but expected "
-              + recordLength + " bytes. Continuing...");
+      + recordLength + " bytes. Continuing...");
     }
     return rawContents;
   }


### PR DESCRIPTION
This is a recurring error due to header problems. Temporary patches #128.

**GitHub issue(s)**:

If you are responding to an issue, please mention their numbers below.

* #128 

# What does this Pull Request do?

This is a minor pull request that basically suppresses errors when ingesting ARC files. Right now, due to issues discussed in #128, every ARC that we ingest says that it is finding 76 less characters than it is expecting.  

Until we have more cycles to substantially rework the ARC record handling, I think suppressing it is a good call.

# How should this be tested?

It should pass on Travis CI. It could also use another set of eyeballs. I have tested it on sample ARC files.

# Additional Notes:

The most important thing is that my knowledge of Java comes from doing the CodeAcademy tutorials this morning, so please keep that in mind. This is very much a rookie trying to take care of low-hanging fruit. But this error message has _bugged me like hell_ for the last two years.

# Interested parties

@ruebot 
