### PR TITLE
Add deprecation warnings to outmoded Arc and Warc formats.

### DIFF
--- a/src/main/java/io/archivesunleashed/io/ArcRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/ArcRecordWritable.java
@@ -14,6 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+ /**
+   *  Features here have been deprecated as of 0.11.0 and will be removed in a
+   *  future release.   Use GenericArchiveRecordWritable (0.11.0) or
+   *  ArchiveRecordWritable (future releases) instead.
+   */
+
 package io.archivesunleashed.io;
 
 import io.archivesunleashed.data.ArcRecordUtils;

--- a/src/main/java/io/archivesunleashed/io/ArcRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/ArcRecordWritable.java
@@ -16,8 +16,8 @@
  */
 
  /**
-   *  Features here have been deprecated as of 0.11.0 and will be removed in a
-   *  future release.   Use GenericArchiveRecordWritable (0.11.0) or
+   *  Features here have been deprecated as of 0.11.0 and will be removed
+   *  in a future release.   Use GenericArchiveRecordWritable (0.11.0) or
    *  ArchiveRecordWritable (future releases) instead.
    */
 

--- a/src/main/java/io/archivesunleashed/io/ArcRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/ArcRecordWritable.java
@@ -17,8 +17,7 @@
 
  /**
    *  @deprecated as of 0.11.0 and will be removed
-   *  in a future release. Use GenericArchiveRecordWritable (0.11.0) or
-   *  ArchiveRecordWritable (future releases) instead.
+   *  in a future release. Use GenericArchiveRecordWritable instead.
    */
 
 package io.archivesunleashed.io;

--- a/src/main/java/io/archivesunleashed/io/ArcRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/ArcRecordWritable.java
@@ -16,7 +16,7 @@
  */
 
  /**
-   *  Features here have been deprecated as of 0.11.0 and will be removed
+   *  @deprecated as of 0.11.0 and will be removed
    *  in a future release.   Use GenericArchiveRecordWritable (0.11.0) or
    *  ArchiveRecordWritable (future releases) instead.
    */
@@ -33,6 +33,7 @@ import org.archive.io.arc.ARCRecord;
 /**
  * Implements Hadoop Writable for ARC Records.
  */
+@Deprecated
 public class ArcRecordWritable implements Writable {
 
   /**

--- a/src/main/java/io/archivesunleashed/io/ArcRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/ArcRecordWritable.java
@@ -17,7 +17,7 @@
 
  /**
    *  @deprecated as of 0.11.0 and will be removed
-   *  in a future release.   Use GenericArchiveRecordWritable (0.11.0) or
+   *  in a future release. Use GenericArchiveRecordWritable (0.11.0) or
    *  ArchiveRecordWritable (future releases) instead.
    */
 

--- a/src/main/java/io/archivesunleashed/io/GenericArchiveRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/GenericArchiveRecordWritable.java
@@ -14,6 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+ /**
+   *  Features here have been deprecated as of 0.11.0 and will be replaced
+   *  with ArchiveRecord Writable in a future release.
+   */
+
 package io.archivesunleashed.io;
 
 import io.archivesunleashed.data.ArcRecordUtils;

--- a/src/main/java/io/archivesunleashed/io/GenericArchiveRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/GenericArchiveRecordWritable.java
@@ -16,7 +16,7 @@
  */
 
  /**
-   *  Features here have been deprecated as of 0.11.0 and will be replaced
+   *  @deprecated as of 0.12.0 and will be replaced
    *  with ArchiveRecordWritable in a future release.
    */
 

--- a/src/main/java/io/archivesunleashed/io/GenericArchiveRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/GenericArchiveRecordWritable.java
@@ -17,7 +17,7 @@
 
  /**
    *  Features here have been deprecated as of 0.11.0 and will be replaced
-   *  with ArchiveRecord Writable in a future release.
+   *  with ArchiveRecordWritable in a future release.
    */
 
 package io.archivesunleashed.io;

--- a/src/main/java/io/archivesunleashed/io/WarcRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/WarcRecordWritable.java
@@ -33,7 +33,7 @@ import org.archive.io.warc.WARCRecord;
 /**
  * Implements Hadoop Writable for WARC Records.
  */
-@Deprecated 
+@Deprecated
 public class WarcRecordWritable implements Writable {
 
   /**

--- a/src/main/java/io/archivesunleashed/io/WarcRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/WarcRecordWritable.java
@@ -14,6 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+ /**
+   *  Features here have been deprecated as of 0.11.0 and will be removed in a
+   *  future release.   Use GenericArchiveRecordWritable (0.11.0) or
+   *  ArchiveRecordWritable (future releases) instead.
+   */
+
 package io.archivesunleashed.io;
 
 import io.archivesunleashed.data.WarcRecordUtils;

--- a/src/main/java/io/archivesunleashed/io/WarcRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/WarcRecordWritable.java
@@ -16,7 +16,7 @@
  */
 
  /**
-   *  Features here have been deprecated as of 0.11.0 and will be removed
+   *  @deprecated as of 0.11.0 and will be removed
    *  in a future release.   Use GenericArchiveRecordWritable (0.11.0) or
    *  ArchiveRecordWritable (future releases) instead.
    */
@@ -33,6 +33,7 @@ import org.archive.io.warc.WARCRecord;
 /**
  * Implements Hadoop Writable for WARC Records.
  */
+@Deprecated 
 public class WarcRecordWritable implements Writable {
 
   /**

--- a/src/main/java/io/archivesunleashed/io/WarcRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/WarcRecordWritable.java
@@ -16,8 +16,8 @@
  */
 
  /**
-   *  Features here have been deprecated as of 0.11.0 and will be removed in a
-   *  future release.   Use GenericArchiveRecordWritable (0.11.0) or
+   *  Features here have been deprecated as of 0.11.0 and will be removed
+   *  in a future release.   Use GenericArchiveRecordWritable (0.11.0) or
    *  ArchiveRecordWritable (future releases) instead.
    */
 

--- a/src/main/java/io/archivesunleashed/io/WarcRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/WarcRecordWritable.java
@@ -17,8 +17,7 @@
 
  /**
    *  @deprecated as of 0.12.0 and will be removed
-   *  in a future release. Use GenericArchiveRecordWritable (0.11.0) or
-   *  ArchiveRecordWritable (future releases) instead.
+   *  in a future release. Use GenericArchiveRecordWritable instead.
    */
 
 package io.archivesunleashed.io;

--- a/src/main/java/io/archivesunleashed/io/WarcRecordWritable.java
+++ b/src/main/java/io/archivesunleashed/io/WarcRecordWritable.java
@@ -16,8 +16,8 @@
  */
 
  /**
-   *  @deprecated as of 0.11.0 and will be removed
-   *  in a future release.   Use GenericArchiveRecordWritable (0.11.0) or
+   *  @deprecated as of 0.12.0 and will be removed
+   *  in a future release. Use GenericArchiveRecordWritable (0.11.0) or
    *  ArchiveRecordWritable (future releases) instead.
    */
 

--- a/src/main/java/io/archivesunleashed/mapreduce/WacArcInputFormat.java
+++ b/src/main/java/io/archivesunleashed/mapreduce/WacArcInputFormat.java
@@ -17,8 +17,7 @@
 
  /**
    *  @deprecated as of 0.12.0 and will be removed
-   *  in a future release. Use WacGenericArchiveInputFormat (0.12.0) or
-   *  WacArchiveInputFormat (future releases) instead.
+   *  in a future release. Use WacGenericArchiveInputFormat instead.
    */
 
 

--- a/src/main/java/io/archivesunleashed/mapreduce/WacArcInputFormat.java
+++ b/src/main/java/io/archivesunleashed/mapreduce/WacArcInputFormat.java
@@ -14,6 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+ /**
+   *  Features here have been deprecated as of 0.11.0 and will be removed in a
+   *  future release.   Use WacGenericArchiveInputFormat (0.11.0) or 
+   *  WacArchiveInputFormat (future releases) instead.
+   */
+
+
 package io.archivesunleashed.mapreduce;
 
 import io.archivesunleashed.io.ArcRecordWritable;

--- a/src/main/java/io/archivesunleashed/mapreduce/WacArcInputFormat.java
+++ b/src/main/java/io/archivesunleashed/mapreduce/WacArcInputFormat.java
@@ -16,7 +16,7 @@
  */
 
  /**
-   *  Features here have been deprecated as of 0.11.0 and will be removed
+   *  @deprecated as of 0.11.0 and will be removed
    *  in a future release.   Use WacGenericArchiveInputFormat (0.11.0) or
    *  WacArchiveInputFormat (future releases) instead.
    */
@@ -49,6 +49,7 @@ import org.archive.io.arc.ARCRecord;
 /**
  * Extends FileInputFormat for Web Archive Commons ARC InputFormat.
  */
+@Deprecated
 public class WacArcInputFormat extends FileInputFormat<LongWritable,
        ArcRecordWritable> {
   @Override
@@ -69,6 +70,7 @@ public class WacArcInputFormat extends FileInputFormat<LongWritable,
   /**
    * Extends RecordReader for ARC Record Reader.
    */
+  @Deprecated
   public class ArcRecordReader extends RecordReader<LongWritable,
          ArcRecordWritable> {
 

--- a/src/main/java/io/archivesunleashed/mapreduce/WacArcInputFormat.java
+++ b/src/main/java/io/archivesunleashed/mapreduce/WacArcInputFormat.java
@@ -16,8 +16,8 @@
  */
 
  /**
-   *  Features here have been deprecated as of 0.11.0 and will be removed in a
-   *  future release.   Use WacGenericArchiveInputFormat (0.11.0) or 
+   *  Features here have been deprecated as of 0.11.0 and will be removed
+   *  in a future release.   Use WacGenericArchiveInputFormat (0.11.0) or
    *  WacArchiveInputFormat (future releases) instead.
    */
 

--- a/src/main/java/io/archivesunleashed/mapreduce/WacArcInputFormat.java
+++ b/src/main/java/io/archivesunleashed/mapreduce/WacArcInputFormat.java
@@ -16,8 +16,8 @@
  */
 
  /**
-   *  @deprecated as of 0.11.0 and will be removed
-   *  in a future release.   Use WacGenericArchiveInputFormat (0.11.0) or
+   *  @deprecated as of 0.12.0 and will be removed
+   *  in a future release. Use WacGenericArchiveInputFormat (0.12.0) or
    *  WacArchiveInputFormat (future releases) instead.
    */
 

--- a/src/main/java/io/archivesunleashed/mapreduce/WacGenericInputFormat.java
+++ b/src/main/java/io/archivesunleashed/mapreduce/WacGenericInputFormat.java
@@ -16,7 +16,7 @@
  */
 
  /**
-   *  Features here have been deprecated as of 0.11.0 and will be replaced
+   *  @deprecated as of 0.12.0 and will be replaced
    *  with WacInputFormat in a future release.
    */
 

--- a/src/main/java/io/archivesunleashed/mapreduce/WacGenericInputFormat.java
+++ b/src/main/java/io/archivesunleashed/mapreduce/WacGenericInputFormat.java
@@ -14,6 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+ /**
+   *  Features here have been deprecated as of 0.11.0 and will be replaced
+   *  with WacInputFormat in a future release.
+   */
+
 package io.archivesunleashed.mapreduce;
 
 import io.archivesunleashed.io.GenericArchiveRecordWritable.ArchiveFormat;

--- a/src/main/java/io/archivesunleashed/mapreduce/WacWarcInputFormat.java
+++ b/src/main/java/io/archivesunleashed/mapreduce/WacWarcInputFormat.java
@@ -16,8 +16,8 @@
  */
 
  /**
-   *  @deprecated as of 0.11.0 and will be removed
-   *  in a future release.   Use WacGenericArchiveInputFormat (0.11.0) or
+   *  @deprecated as of 0.12.0 and will be removed
+   *  in a future release. Use WacGenericArchiveInputFormat (0.11.0) or
    *  WacArchiveInputFormat (future releases) instead.
    */
 

--- a/src/main/java/io/archivesunleashed/mapreduce/WacWarcInputFormat.java
+++ b/src/main/java/io/archivesunleashed/mapreduce/WacWarcInputFormat.java
@@ -14,6 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+ /**
+   *  Features here have been deprecated as of 0.11.0 and will be removed in a
+   *  future release.   Use WacGenericArchiveInputFormat (0.11.0) or
+   *  WacArchiveInputFormat (future releases) instead.
+   */
+
 package io.archivesunleashed.mapreduce;
 
 import io.archivesunleashed.io.WarcRecordWritable;

--- a/src/main/java/io/archivesunleashed/mapreduce/WacWarcInputFormat.java
+++ b/src/main/java/io/archivesunleashed/mapreduce/WacWarcInputFormat.java
@@ -17,8 +17,7 @@
 
  /**
    *  @deprecated as of 0.12.0 and will be removed
-   *  in a future release. Use WacGenericArchiveInputFormat (0.11.0) or
-   *  WacArchiveInputFormat (future releases) instead.
+   *  in a future release. Use WacGenericArchiveInputFormat instead.
    */
 
 package io.archivesunleashed.mapreduce;

--- a/src/main/java/io/archivesunleashed/mapreduce/WacWarcInputFormat.java
+++ b/src/main/java/io/archivesunleashed/mapreduce/WacWarcInputFormat.java
@@ -16,8 +16,8 @@
  */
 
  /**
-   *  Features here have been deprecated as of 0.11.0 and will be removed in a
-   *  future release.   Use WacGenericArchiveInputFormat (0.11.0) or
+   *  Features here have been deprecated as of 0.11.0 and will be removed
+   *  in a future release.   Use WacGenericArchiveInputFormat (0.11.0) or
    *  WacArchiveInputFormat (future releases) instead.
    */
 

--- a/src/main/java/io/archivesunleashed/mapreduce/WacWarcInputFormat.java
+++ b/src/main/java/io/archivesunleashed/mapreduce/WacWarcInputFormat.java
@@ -16,7 +16,7 @@
  */
 
  /**
-   *  Features here have been deprecated as of 0.11.0 and will be removed
+   *  @deprecated as of 0.11.0 and will be removed
    *  in a future release.   Use WacGenericArchiveInputFormat (0.11.0) or
    *  WacArchiveInputFormat (future releases) instead.
    */
@@ -48,6 +48,7 @@ import org.archive.io.warc.WARCRecord;
 /**
  * Extends FileInputFormat for Web Archive Commons WARC InputFormat.
  */
+@Deprecated
 public class WacWarcInputFormat extends FileInputFormat<LongWritable,
        WarcRecordWritable> {
   @Override


### PR DESCRIPTION
**Add Deprecation warnings to Arc & Warc Writeable and Input Formats**

* * *

**GitHub issue(s)**:

Related to discussion in #80. 

# What does this Pull Request do?

Add deprecation warnings to unused Warc and Arc java files.

# How should this be tested?

N/A

# Additional Notes:

@lintool suggests that this code has other potential purposes in https://github.com/archivesunleashed/aut/issues/102#issuecomment-340195847 so I recommend having his okay before merging.  Alternately, it may be good to have a nice place to store this code somewhere. 

https://github.com/archivesunleashed/aut/commit/5bc95a1d09d11ae5f74a72a18ea7c33b174c65b0 contains working code for removal in the next cycle.

# Interested parties

@lintool 

Thanks in advance for your help with the Archives Unleashed Toolkit!
