### PR TITLE
Remove stackTrace output on caught error.

### DIFF
--- a/src/main/scala/io/archivesunleashed/spark/matchbox/ComputeImageSize.scala
+++ b/src/main/scala/io/archivesunleashed/spark/matchbox/ComputeImageSize.scala
@@ -32,7 +32,6 @@ object ComputeImageSize {
       (image.getWidth(), image.getHeight())
     } catch {
       case e: Throwable => {
-        e.printStackTrace()
         return (0, 0)
       }
     }

--- a/src/test/scala/io/archivesunleashed/spark/matchbox/ComputeImageSizeTest.scala
+++ b/src/test/scala/io/archivesunleashed/spark/matchbox/ComputeImageSizeTest.scala
@@ -32,10 +32,9 @@ class ComputeImageSizeTest extends FunSuite {
   var image: Array[Byte] = ios.toByteArray();
   ios.close()
 
-
   test ("check images") {
     assert(ComputeImageSize(image) == (10, 10))
     assert(ComputeImageSize(Array[Byte](0,0,0)) == (0, 0))
-    assert (ComputeImageSize(null) == (0,0))
+    assert(ComputeImageSize(null) == (0,0))
   }
 }


### PR DESCRIPTION
**Remove Stack Trace Output on an Expected Error**

* * *

**GitHub issue(s)**:

#124 

# What does this Pull Request do?

Unit tests were producing a "NullPointerError" that was caught and then thrown during the testing period.  

Since the try-catch call is both expected on a ComputeImageSize(null) and returns (0,0) regardless, there is not reason to output the stack trace here.

# How should this be tested?

Compilation does not print out NullPointer error anymore.

# Additional Notes:
N/A

# Interested parties

Tag (@ mention) interested parties.

Thanks in advance for your help with the Archives Unleashed Toolkit!
