### PR TITLE
Changes jsoup version in pom.xml (#154)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.11.1</version>
+      <version>1.7.3</version>
     </dependency>
     <dependency>
       <groupId>org.netpreserve.commons</groupId>


### PR DESCRIPTION
As seen in [Issue 154](https://github.com/archivesunleashed/aut/issues/154), the changed jsoup version seems to have blown up link extraction in some ARC files. 

I've verified on multiple systems, and with version 1.7.3 it works and on version 1.11.1 it fails, at least with the Canadian labour collection.

That said, we changed to version 1.11.1 to resolve [this issue](https://github.com/archivesunleashed/aut/issues/113), so I'm not sure what the best way to proceed is. I am also very inexperienced in dependency issues, so am completely deferring here.