### PR TITLE
Changing keepDate to allow multiple dates, would close #108

### DIFF
--- a/src/main/scala/io/archivesunleashed/spark/rdd/RecordRDD.scala
+++ b/src/main/scala/io/archivesunleashed/spark/rdd/RecordRDD.scala
@@ -73,8 +73,8 @@ object RecordRDD extends java.io.Serializable {
       rdd.filter(r => mimeTypes.contains(r.getMimeType))
     }
 
-    def keepDate(date: String, component: DateComponent = DateComponent.YYYYMMDD) = {
-      rdd.filter(r => ExtractDate(r.getCrawlDate, component) == date)
+    def keepDate(dates: List[String], component: DateComponent = DateComponent.YYYYMMDD) = {
+      rdd.filter(r => dates.contains(ExtractDate(r.getCrawlDate, component)))
     }
 
     def keepUrls(urls: Set[String]) = {

--- a/src/test/scala/io/archivesunleashed/spark/ArcTest.scala
+++ b/src/test/scala/io/archivesunleashed/spark/ArcTest.scala
@@ -45,12 +45,12 @@ class ArcTest extends FunSuite with BeforeAndAfter {
 
   test("filter date") {
     val four = RecordLoader.loadArchives(arcPath, sc, keepValidPages = false)
-      .keepDate(List("200804"), DateComponent.YYYYMM)
+      .keepDate(List("200804","200805"), DateComponent.YYYYMM)
       .map(r => r.getCrawlDate)
       .collect()
 
     val five = RecordLoader.loadArchives(arcPath, sc, keepValidPages = false)
-      .keepDate(List("200805"), DateComponent.YYYYMM)
+      .keepDate(List("200805","200807"), DateComponent.YYYYMM)
       .map(r => r.getCrawlDate)
       .collect()
 

--- a/src/test/scala/io/archivesunleashed/spark/ArcTest.scala
+++ b/src/test/scala/io/archivesunleashed/spark/ArcTest.scala
@@ -45,12 +45,12 @@ class ArcTest extends FunSuite with BeforeAndAfter {
 
   test("filter date") {
     val four = RecordLoader.loadArchives(arcPath, sc, keepValidPages = false)
-      .keepDate("200804", DateComponent.YYYYMM)
+      .keepDate(List("200804"), DateComponent.YYYYMM)
       .map(r => r.getCrawlDate)
       .collect()
 
     val five = RecordLoader.loadArchives(arcPath, sc, keepValidPages = false)
-      .keepDate("200805", DateComponent.YYYYMM)
+      .keepDate(List("200805"), DateComponent.YYYYMM)
       .map(r => r.getCrawlDate)
       .collect()
 

--- a/src/test/scala/io/archivesunleashed/spark/rdd/RecordRDDTest.scala
+++ b/src/test/scala/io/archivesunleashed/spark/rdd/RecordRDDTest.scala
@@ -62,7 +62,7 @@ class RecordRDDTest extends FunSuite with BeforeAndAfter {
     val r = base
       .filter (x => ExtractDate(x.getCrawlDate, component) == "2008")
       .map ( mp => mp.getUrl).take(3)
-    val r2 = base.keepDate("2008", component)
+    val r2 = base.keepDate(List("2008"), component)
       .map ( mp => mp.getUrl).take(3)
     assert (r2.sameElements(r)) }
 


### PR DESCRIPTION
**GitHub issue(s)**:

If you are responding to an issue, please mention their numbers below.

* #108

# What does this Pull Request do?

This Pull Request changes the use of `keepDate`. Right now, it is used like: 

```
  .keepDate("2008", YYYY)
```

If a user wanted data from 2008 and 2010, they would have to run two separate scripts - one for 2008 and one for 2010.

This new format allows the use of a list in `keepDate`, so a command like:

```
  .keepDate(List("2007","2010"), YYYY)
```

# How should this be tested?

I have tested this on a collection of WARCs with files from 2007 and from 2010. Running:

```
import io.archivesunleashed.spark.matchbox.RecordLoader
import io.archivesunleashed.spark.rdd.RecordRDD._
import io.archivesunleashed.spark.matchbox.{RemoveHTML, RecordLoader}
import io.archivesunleashed.spark.matchbox.ExtractDate.DateComponent._

RecordLoader.loadArchives("/Users/ianmilligan1/dropbox/testdata/*.gz", sc)
  .keepValidPages()
  .keepDate(List("2007","2010"), YYYY)
  .map(r => (r.getCrawlDate, r.getDomain, r.getUrl, RemoveHTML(r.getContentString)))
  .saveAsTextFile("/users/ianmilligan1/desktop/output/2007and2010")
```

Resulted in all the records from 2007 and 2010. You can also still test only one year, but it still needs to be provided as a list.

# Additional Notes:

If approved, this will require revision to all `keepDate` documentation.

# Interested parties

@ruebot @greebie @lintool 
