### PR TITLE
Fix bug -- label type should be "string" not "label".

### DIFF
--- a/src/main/scala/io/archivesunleashed/spark/matchbox/WriteGraphML.scala
+++ b/src/main/scala/io/archivesunleashed/spark/matchbox/WriteGraphML.scala
@@ -58,7 +58,7 @@ object WriteGraphML {
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
                http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-        <key id="n0" for="node" attr.name="label" attr.type="label">
+        <key id="n0" for="node" attr.name="label" attr.type="string">
           <default>""</default>
         </key>
         <key id="e0" for="edge" attr.name="weight" attr.type="double">


### PR DESCRIPTION
**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**

Fixes bug in graphml.  The var type for label was "label" instead of "string."  Gephi would be forgiving, but my C script was not!

* * *

**GitHub issue(s)**:

If you are responding to an issue, please mention their numbers below.

N/A

# What does this Pull Request do?

Change label type to "string" instead of "label".

# How should this be tested?

Other than travis, none.  We will see if it works in the borgreducer once completed.

# Additional Notes:

# Interested parties

@ianmilligan1 

Thanks in advance for your help with the Archives Unleashed Toolkit!
