### PR TITLE
Gexf Fixes & StringUtil Functions #172

### DIFF
--- a/src/main/scala/io/archivesunleashed/spark/matchbox/StringUtils.scala
+++ b/src/main/scala/io/archivesunleashed/spark/matchbox/StringUtils.scala
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 package io.archivesunleashed.spark.matchbox
+import scala.xml.Utility.escape
+import java.io.IOException
+import java.security.MessageDigest
 
 object StringUtils {
 
@@ -23,6 +26,19 @@ object StringUtils {
       if (s == null) return null
       s.replaceAll("^\\s*www\\.", "")
     }
-  }
 
+    def escapeInvalidXML(): String = {
+      try {
+        return escape(s)
+      }
+      catch {
+        case e: Exception => throw new IOException("Caught exception processing input row ", e)
+      }
+    }
+
+    def computeHash(): String = {
+      val md5 = MessageDigest.getInstance("MD5")
+      return md5.digest(s.getBytes).map("%02x".format(_)).mkString
+    }
+  }
 }

--- a/src/main/scala/io/archivesunleashed/spark/matchbox/WriteGEXF.scala
+++ b/src/main/scala/io/archivesunleashed/spark/matchbox/WriteGEXF.scala
@@ -45,7 +45,7 @@ object WriteGEXF {
     val outFile = Files.newBufferedWriter(Paths.get(gexfPath), StandardCharsets.UTF_8)
     val edges = rdd.map(r => "<edge source=\"" + r._1._2.computeHash() + "\" target=\"" +
       r._1._3.computeHash() + "\" weight=\"" + r._2 +
-      " type=\"directed\">\n" +
+      "\" type=\"directed\">\n" +
       "<attvalues>\n" +
       "<attvalue for=\"0\" value=\"" + r._1._1 + "\" />\n" +
       "</attvalues>\n" +

--- a/src/main/scala/io/archivesunleashed/spark/matchbox/WriteGEXF.scala
+++ b/src/main/scala/io/archivesunleashed/spark/matchbox/WriteGEXF.scala
@@ -22,6 +22,8 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 import org.apache.spark.rdd.RDD
+import StringUtils._
+
 
 /**
   * UDF for exporting an RDD representing a collection of links to a GDF file.
@@ -41,38 +43,34 @@ object WriteGEXF {
 
   def makeFile (rdd: RDD[((String, String, String), Int)], gexfPath: String): Boolean = {
     val outFile = Files.newBufferedWriter(Paths.get(gexfPath), StandardCharsets.UTF_8)
-    val edges = rdd.map(r => "      <edge source=\"" + r._1._2 + "\" target=\"" +
-      r._1._3 + "\" label=\"\" weight=\"" + r._2 +
-      """"  type="directed">
-      <attvalues>
-      <attvalue for="0" value="""" + r._1._1 + """" />
-      </attvalues>
-      </edge>""").collect
-    val nodes = rdd.flatMap(r => List("      <node id=\"" +
-      r._1._2 + "\" label=\"" +
-      r._1._2 + "\" />\n",
-      "      <node id=\"" +
-      r._1._3 + "\" label=\"" +
-      r._1._3 + "\" />")).distinct.collect
-    outFile.write("""<?xml version="1.0" encoding="UTF-8"?>
-      <gexf xmlns="http://www.gexf.net/1.3draft"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://www.gexf.net/1.3draft
-                                http://www.gexf.net/1.3draft/gexf.xsd"
-            version="1.3">
-        <graph mode="static" defaultedgetype="directed">
-          <attributes class="edge">
-            <attribute id="0" title="crawlDate" type="string" />
-          </attributes>
-          <nodes>""")
-    nodes.foreach(r => outFile.write(r + "\n"))
-    outFile.write("""    </nodes>
-      <edges>
-      """)
-    edges.foreach(r => outFile.write(r + "\n"))
-    outFile.write("""    </edges>
-        </graph>
-      </gexf>""")
+    val edges = rdd.map(r => "<edge source=\"" + r._1._2.computeHash() + "\" target=\"" +
+      r._1._3.computeHash() + "\" weight=\"" + r._2 +
+      " type=\"directed\">\n" +
+      "<attvalues>\n" +
+      "<attvalue for=\"0\" value=\"" + r._1._1 + "\" />\n" +
+      "</attvalues>\n" +
+      "</edge>\n").collect
+    val nodes = rdd.flatMap(r => List("<node id=\"" +
+      r._1._2.computeHash() + "\" label=\"" +
+      r._1._2.escapeInvalidXML() + "\" />\n",
+      "<node id=\"" +
+      r._1._3.computeHash() + "\" label=\"" +
+      r._1._3.escapeInvalidXML() + "\" />\n")).distinct.collect
+    outFile.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+      "<gexf xmlns=\"http://www.gexf.net/1.3draft\"\n" +
+      "  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+      "  xsi:schemaLocation=\"http://www.gexf.net/1.3draft\n" +
+      "                       http://www.gexf.net/1.3draft/gexf.xsd\"\n" +
+      "  version=\"1.3\">\n" +
+      "<graph mode=\"static\" defaultedgetype=\"directed\">\n" +
+      "<attributes class=\"edge\">\n" +
+      "  <attribute id=\"0\" title=\"crawlDate\" type=\"string\" />\n" +
+      "</attributes>\n" +
+      "<nodes>\n")
+    nodes.foreach(r => outFile.write(r))
+    outFile.write("</nodes>\n<edges>\n")
+    edges.foreach(r => outFile.write(r))
+    outFile.write("</edges>\n</graph>\n</gexf>")
     outFile.close()
     return true
   }

--- a/src/test/scala/io/archivesunleashed/spark/matchbox/StringUtilsTest.scala
+++ b/src/test/scala/io/archivesunleashed/spark/matchbox/StringUtilsTest.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package io.archivesunleashed.spark.matchbox
-
+import java.io.IOException
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -28,5 +28,17 @@ class StringUtilsTest extends FunSuite {
     val n: String = null
     assert(s.removePrefixWWW() == "example.com")
     assert(n.removePrefixWWW() == null)
+  }
+
+  test("create hash") {
+    val invalid: String = "A<B>C&D\"";
+    val except: String = null;
+    assert(invalid.escapeInvalidXML() == "A&lt;B&gt;C&amp;D&quot;");
+    val caught = intercept[IOException] {except.escapeInvalidXML()}
+    assert (caught.getMessage == "Caught exception processing input row ");
+  }
+  test ("md5 hash") {
+    val s: String = "unesco.org";
+    assert(s.computeHash() == "8e8decc8e8107bcf9d3896f3222b77d8");
   }
 }

--- a/src/test/scala/io/archivesunleashed/spark/matchbox/WriteGEXFTest.scala
+++ b/src/test/scala/io/archivesunleashed/spark/matchbox/WriteGEXFTest.scala
@@ -50,10 +50,11 @@ class WriteGEXFTest extends FunSuite with BeforeAndAfter{
     WriteGEXF(networkrdd, testFile)
     assert(Files.exists(Paths.get(testFile)) == true)
     val lines = Source.fromFile(testFile).getLines.toList
+    println(lines)
     assert(lines(0) == """<?xml version="1.0" encoding="UTF-8"?>""")
-    assert(lines(16) == """      <node id="Source3" label="Source3" />""")
-    assert(lines(18) == """      <node id="Destination1" label="Destination1" />""")
-    assert(lines(21) == """            <edge source="Source1" target="Destination1" label="" weight="3"  type="directed">""")
+    assert(lines(12) == """<node id="f61def1ec71cd27401b8c821f04b7c27" label="Destination1" />""")
+    assert(lines(22) == """</attvalues>""")
+    assert(lines(34) == """</edges>""")
   }
 
   test ("returns a Bool depending on pass or failure") {


### PR DESCRIPTION
- add hash for ids in gexf
- add escaper for xml
- move hash udf to string utils
- improve output for gexf

**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**

* * *

**GitHub issue(s)**:

If you are responding to an issue, please mention their numbers below.

#172

# What does this Pull Request do?

- Provides udf for escaping non-xml friendly characters.
- Move md5 hash function to StringUtils
- Fixes Gexf problems due to faulty data

# How should this be tested?

Broken outputs should be tested in Gephi.

# Additional Notes:

Simply adding &<> or " to a url output can suffice as a broken string.

# Interested parties

@ianmilligan1 

Thanks in advance for your help with the Archives Unleashed Toolkit!
