### PR TITLE
Revert "make ArchiveRecord a trait (#175)"

### DIFF
--- a/src/main/scala/io/archivesunleashed/spark/archive/io/ArchiveRecord.scala
+++ b/src/main/scala/io/archivesunleashed/spark/archive/io/ArchiveRecord.scala
@@ -29,31 +29,7 @@ import io.archivesunleashed.io.ArchiveRecordWritable.ArchiveFormat
 import io.archivesunleashed.spark.matchbox.ExtractDate.DateComponent
 import io.archivesunleashed.spark.matchbox.{RemoveHttpHeader, ExtractDate, ExtractDomain}
 
-object ArchiveRecord {
-  val ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX")
-}
-
-trait ArchiveRecord extends Serializable {
-  def getCrawlDate: String
-
-  def getCrawlMonth: String
-
-  def getContentBytes: Array[Byte]
-
-  def getContentString: String
-
-  def getMimeType: String
-
-  def getUrl: String
-
-  def getDomain: String
-
-  def getImageBytes: Array[Byte]
-}
-
-class ArchiveRecordImpl(r: SerializableWritable[ArchiveRecordWritable]) extends ArchiveRecord {
-  import ArchiveRecord._
-
+class ArchiveRecord(r: SerializableWritable[ArchiveRecordWritable]) extends Serializable {
   var arcRecord: ARCRecord = null
   var warcRecord: WARCRecord = null
 
@@ -61,6 +37,9 @@ class ArchiveRecordImpl(r: SerializableWritable[ArchiveRecordWritable]) extends 
     arcRecord = r.t.getRecord.asInstanceOf[ARCRecord]
   else if (r.t.getFormat == ArchiveFormat.WARC)
     warcRecord = r.t.getRecord.asInstanceOf[WARCRecord]
+
+
+  val ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX")
 
   val getCrawlDate: String = {
     if (r.t.getFormat == ArchiveFormat.ARC) {
@@ -88,7 +67,7 @@ class ArchiveRecordImpl(r: SerializableWritable[ArchiveRecordWritable]) extends 
 
   val getContentString: String = new String(getContentBytes)
 
-  val getMimeType: String = {
+  val getMimeType = {
     if (r.t.getFormat == ArchiveFormat.ARC) {
       arcRecord.getMetaData.getMimetype
     } else {
@@ -96,7 +75,7 @@ class ArchiveRecordImpl(r: SerializableWritable[ArchiveRecordWritable]) extends 
     }
   }
 
-  val getUrl: String = {
+  val getUrl = {
     if (r.t.getFormat == ArchiveFormat.ARC) {
       arcRecord.getMetaData.getUrl
     } else {

--- a/src/main/scala/io/archivesunleashed/spark/matchbox/RecordLoader.scala
+++ b/src/main/scala/io/archivesunleashed/spark/matchbox/RecordLoader.scala
@@ -24,7 +24,7 @@ import org.json4s.jackson.JsonMethods._
 import io.archivesunleashed.io.ArchiveRecordWritable.ArchiveFormat
 import io.archivesunleashed.io.ArchiveRecordWritable
 import io.archivesunleashed.mapreduce.WacInputFormat
-import io.archivesunleashed.spark.archive.io._
+import io.archivesunleashed.spark.archive.io.ArchiveRecord
 import io.archivesunleashed.spark.rdd.RecordRDD._
 
 object RecordLoader {
@@ -34,7 +34,7 @@ object RecordLoader {
       sc.newAPIHadoopFile(path, classOf[WacInputFormat], classOf[LongWritable], classOf[ArchiveRecordWritable])
       .filter(r => (r._2.getFormat == ArchiveFormat.ARC) ||
         ((r._2.getFormat == ArchiveFormat.WARC) && r._2.getRecord.getHeader.getHeaderValue("WARC-Type").equals("response")))
-      .map(r => new ArchiveRecordImpl(new SerializableWritable(r._2)))
+      .map(r => new ArchiveRecord(new SerializableWritable(r._2)))
 
     if (keepValidPages) rdd.keepValidPages() else rdd
   }


### PR DESCRIPTION
This reverts commit cd0d7b03854db80dc67f8076aff44f1b4c2364b2.

# What does this Pull Request do?

Reverts @helgeho's trait work.

I was under the impression that #175 was tested in a way that it was not tested by @greebie before I merged it. Unfortunately this breaks in a number of ways that can be seen [here](https://gist.github.com/ruebot/97040d25cdc7f110869be9529b332a61#file-0-13-0).

# How should this be tested?

This is just rolling back to basically 0.12.2, and it should be working fine. @ianmilligan1 would you mind testing this on one of our small WALK datasets? I was using Ransom Myers. So, anything you have laying around should be great. No drop everything super rush here. Sometime this week if you have time.

# Additional Notes:

I'll be putting a note on the [0.13.0 release](https://github.com/archivesunleashed/aut/releases/tag/aut-0.13.0) mentioning that is broken, and not to use it. We can't remove releases from Maven Central, so I'll just have to cut a new release once this is merged.

Moving forward, I think we need to come up with a set of tests, or extend the existing tests that that can catch how we failed here. I think it would be better to have our unit tests capture potential traps that happened here rather than a battery of testing on various datasets.

@helgeho moving forward, let me know how you want to proceed with the work done in https://github.com/archivesunleashed/aut/pull/175. I think it is a good idea, and really great that our projects can be connected. So, hopefully we can get something going again :smile: