### PR TITLE
Resolve #176; setup scaladocs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Build Status](https://travis-ci.org/archivesunleashed/aut.svg?branch=master)](https://travis-ci.org/archivesunleashed/aut)
 [![codecov](https://codecov.io/gh/archivesunleashed/aut/branch/master/graph/badge.svg)](https://codecov.io/gh/archivesunleashed/aut)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.archivesunleashed/aut/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.archivesunleashed/aut)
+[![Javadoc](https://javadoc-badge.appspot.com/io.archivesunleashed/aut.svg?label=javadoc)](http://java.docs.archivesunleashed.io/0.13.0/apidocs/index.html)
+[![Scaladoc](https://javadoc-badge.appspot.com/io.archivesunleashed/aut.svg?label=scaladoc)](http://java.docs.archivesunleashed.io/0.13.0/scaladocs/index.html)
 [![LICENSE](https://img.shields.io/badge/license-Apache-blue.svg?style=flat-square)](./LICENSE)
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,12 @@
     <deploy.plugin.version>2.8.2</deploy.plugin.version>
     <site.plugin.version>3.6</site.plugin.version>
     <doxia-markdown.plugin.version>1.7</doxia-markdown.plugin.version>
+    <failsafe.plugin.version>2.18.1</failsafe.plugin.version>
+    <javadoc.plugin.version>2.10.3</javadoc.plugin.version>
+    <jxr.plugin.version>2.5</jxr.plugin.version>
+    <surefire.plugin.version>2.18.1</surefire.plugin.version>
+    <jacoco.plugin.version>0.7.5.201505241946</jacoco.plugin.version>
+    <versions.plugin.version>2.1</versions.plugin.version>
   </properties>
 
   <licenses>
@@ -330,6 +336,12 @@
         <configuration>
           <linksource>true</linksource>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.3.2</version>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
**GitHub issue(s)**:

#176

# What does this Pull Request do?

* Setups up the requirement to generate scaladocs in `pom.xml`
* Add some missing versions to the `pom.xml`
* Adds badges to README (scaladocs badge link won't work until after the new release)

# How should this be tested?

* TravisCI should pass
* Locally:
  * `git clone -b issue-176 https://github.com/ruebot/aut.git`
  * `cd aut`
  * `mvn site`
  * verify that `target/site/scaladocs` exists, and `target/site/scaladocs/index.html` opens fine

You'll see something like this when building:

```
/home/nruest/git/aut/src/main/scala/io/archivesunleashed/spark/matchbox/ExtractGraph.scala:30: warning: Variable nodes undefined in comment for object ExtractGraph in object ExtractGraph
  * $ jq -c -n --slurpfile nodes nodes.json --slurpfile links links.json '{nodes: $nodes, links: $links}' > graph.json
                                                                                   ^
/home/nruest/git/aut/src/main/scala/io/archivesunleashed/spark/matchbox/ExtractGraph.scala:30: warning: Variable links undefined in comment for object ExtractGraph in object ExtractGraph
  * $ jq -c -n --slurpfile nodes nodes.json --slurpfile links links.json '{nodes: $nodes, links: $links}' > graph.json
                                                                                                  ^
two warnings found
```

Don't be alarmed. It's fine. We'll have a follow-up issue (see below).


![screenshot from 2018-03-20 09-03-22](https://user-images.githubusercontent.com/218561/37656128-8985ab8a-2c1d-11e8-82de-82b23a8f381a.png)


# Additional Notes

* Once this gets merged, I'll start working on the next release.
* I'll also be creating a ticket to clean up the doc comments on the scala files in the project. They aren't exactly the best :wink: 