### PR TITLE
fix #199: mime-type was incorrectly parsed from content-type when cha…

### DIFF
--- a/src/main/java/io/archivesunleashed/data/WarcRecordUtils.java
+++ b/src/main/java/io/archivesunleashed/data/WarcRecordUtils.java
@@ -98,7 +98,8 @@ public final class WarcRecordUtils implements WARCConstants {
     // This is a somewhat janky way to get the MIME type of the response.
     // Moreover the parser is not fully complaint to the specification.
     // See: https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
-    // It would be much better to parse all headers using org.apache.commons.httpclient.HeaderElement
+    // It would be much better to parse all headers using an external library:
+    //   org.apache.commons.httpclient.HeaderElement
     // Note that this is different from the "Content-Type" in the WARC header.
     Pattern pattern = Pattern.compile("Content-Type: ([^\\s;]+) *(;.*)?",
             Pattern.CASE_INSENSITIVE);

--- a/src/main/java/io/archivesunleashed/data/WarcRecordUtils.java
+++ b/src/main/java/io/archivesunleashed/data/WarcRecordUtils.java
@@ -96,8 +96,11 @@ public final class WarcRecordUtils implements WARCConstants {
    */
   public static String getWarcResponseMimeType(final byte[] contents) {
     // This is a somewhat janky way to get the MIME type of the response.
+    // Moreover the parser is not fully complaint to the specification.
+    // See: https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
+    // It would be much better to parse all headers using org.apache.commons.httpclient.HeaderElement
     // Note that this is different from the "Content-Type" in the WARC header.
-    Pattern pattern = Pattern.compile("Content-Type: ([^\\s]+)",
+    Pattern pattern = Pattern.compile("Content-Type: ([^\\s;]+) *(;.*)?",
             Pattern.CASE_INSENSITIVE);
     Matcher matcher = pattern.matcher(new String(contents));
     if (matcher.find()) {

--- a/src/main/java/io/archivesunleashed/data/WarcRecordUtils.java
+++ b/src/main/java/io/archivesunleashed/data/WarcRecordUtils.java
@@ -96,7 +96,7 @@ public final class WarcRecordUtils implements WARCConstants {
    */
   public static String getWarcResponseMimeType(final byte[] contents) {
     // This is a somewhat janky way to get the MIME type of the response.
-    // Moreover the parser is not fully complaint to the specification.
+    // Moreover, this simple regex is not compliant with the specification.
     // See: https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
     // It would be much better to parse all headers using an external library:
     //   org.apache.commons.httpclient.HeaderElement

--- a/src/test/java/io/archivesunleashed/data/WarcLoaderTest.java
+++ b/src/test/java/io/archivesunleashed/data/WarcLoaderTest.java
@@ -153,4 +153,11 @@ public class WarcLoaderTest {
     LOG.info(cnt + " records read!");
     assertEquals(cntTest, cnt);
   }
+
+  @Test
+  public final void testContentTypeWithCharset() throws Exception {
+    byte[] content = "Content-Type: text/html;charset=ISO-8859-1\r\n".getBytes("UTF-8");
+    String mimeType = WarcRecordUtils.getWarcResponseMimeType(content);
+    assertEquals("text/html", mimeType);
+  }
 }

--- a/src/test/java/io/archivesunleashed/data/WarcLoaderTest.java
+++ b/src/test/java/io/archivesunleashed/data/WarcLoaderTest.java
@@ -156,8 +156,9 @@ public class WarcLoaderTest {
 
   @Test
   public final void testContentTypeWithCharset() throws Exception {
-    byte[] content = "Content-Type: text/html;charset=ISO-8859-1\r\n".getBytes("UTF-8");
-    String mimeType = WarcRecordUtils.getWarcResponseMimeType(content);
+    String content = "Content-Type: text/html;charset=ISO-8859-1\r\n";
+    byte[] contentBytes = content.getBytes("UTF-8");
+    String mimeType = WarcRecordUtils.getWarcResponseMimeType(contentBytes);
     assertEquals("text/html", mimeType);
   }
 }


### PR DESCRIPTION
fix #199: mime-type was incorrectly parsed from content-type when charset param exists

* * *

**GitHub issue(s)**:

If you are responding to an issue, please mention their numbers below.
#199 

# What does this Pull Request do?
Calling `WarcRecordUtils.getWarcResponseMimeType` with a header such as `Content-Type: text/html;charset=ISO-8859-1` should return `text/html`. However it was returning `text/html;charset=ISO-8859-1`. Also, the function `keepValidPages` was not working properly because of this.

This pull request fixes this issue.


# How should this be tested?
A unit test was added: `WarcLoaderTest.testContentTypeWithCharset`

# Additional Notes:

Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated?
No

* Does this change add any new dependencies?
No

* Could this change or impact execution of existing code?
No

# Interested parties

Tag (@ mention) interested parties.

Thanks in advance for your help with the Archives Unleashed Toolkit!