### PR TITLE
Implement DomainFrequency, DomainGraph and PlainText extractor that can be run from command line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -580,6 +580,11 @@
       <artifactId>tika-parsers</artifactId>
       <version>1.12</version>
     </dependency>
+    <dependency>
+      <groupId>org.rogach</groupId>
+      <artifactId>scallop_2.12</artifactId>
+      <version>3.1.2</version>
+    </dependency>
     <dependency>  <!-- needed for running boilerpipe, but will compile without -->
       <groupId>com.syncthemall</groupId>
       <artifactId>boilerpipe</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -582,7 +582,7 @@
     </dependency>
     <dependency>
       <groupId>org.rogach</groupId>
-      <artifactId>scallop_2.12</artifactId>
+      <artifactId>scallop_2.11</artifactId>
       <version>3.1.2</version>
     </dependency>
     <dependency>  <!-- needed for running boilerpipe, but will compile without -->

--- a/src/main/scala/io/archivesunleashed/app/CommandLineAppRunner.scala
+++ b/src/main/scala/io/archivesunleashed/app/CommandLineAppRunner.scala
@@ -17,8 +17,12 @@
 
 package io.archivesunleashed.app
 
-import io.archivesunleashed.RecordLoader
+import java.io.File
+import java.nio.file.{Files, Paths}
+
+import io.archivesunleashed.{ArchiveRecord, RecordLoader}
 import org.apache.log4j.Logger
+import org.apache.spark.rdd.RDD
 import org.apache.spark.{SparkConf, SparkContext}
 import org.rogach.scallop.ScallopConf
 
@@ -27,11 +31,19 @@ import org.rogach.scallop.ScallopConf
  * PATH_TO_SPARK 
  *   --class io.archivesunleashed.app.CommandLineAppRunner 
  *   PATH_TO_AUT_JAR
- *   EXTRACTOR
- *   INPUT_FILE
- *   OUTPUT_DIRECTORY
+ *   --extractor EXTRACTOR
+ *   --input INPUT_FILE ...
+ *   --output OUTPUT_DIRECTORY
+ *   [--output-format FORMAT]
  *   
- * where EXTRACTOR is one of domainFreq, domainGraph or plainText
+ * where EXTRACTOR is one of
+ * DomainFrequencyExtractor, DomainGraphExtractor or PlainTextExtractor
+ *
+ * INPUT_FILE is a list of input files separated by space (or path containing wildcard)
+ * OUTPUT_DIRECTORY is the directory to put result in
+ *
+ * FORMAT is meant to work with DomainGraphExtractor
+ * Two supported options are TEXT (default) or GEXF
  */
 
 object CommandLineAppRunner {
@@ -40,34 +52,64 @@ object CommandLineAppRunner {
   class Conf(args: Seq[String]) extends ScallopConf(args) {
     mainOptions = Seq(input, output)
     var extractor = opt[String](descr =
-      "extractor, one of domainFreq, domainGraph or plainText", required = true)
-    val input = opt[String](descr = "input path", required = true)
-    val output = opt[String](descr = "output path", required = true)
+      "extractor", required = true)
+    val input = opt[List[String]](descr = "input file path", required = true)
+    val output = opt[String](descr = "output directory path", required = true)
+    val outputFormat = opt[String](descr =
+      "output format for DomainGraphExtractor, one of TEXT or GEXF")
     verify()
   }
 
   def main(argv: Array[String]): Unit = {
-    print(argv(0))
-    var args = new Conf(argv)
+    val args = new Conf(argv)
 
-    log.info("Extractor: " + args.extractor())
-    log.info("Input: " + args.input())
-    log.info("Output: " + args.output())
+    val extractors = Map[String, (RDD[ArchiveRecord], String) => Any](
+      "DomainFrequencyExtractor" ->
+        ((rdd: RDD[ArchiveRecord], subFolder: String) => {
+          DomainFrequencyExtractor(rdd).saveAsTextFile(subFolder)}),
+    "DomainGraphExtractor" ->
+      ((rdd: RDD[ArchiveRecord], subFolder: String) => {
+        if (!args.outputFormat.isEmpty && args.outputFormat() == "GEXF") {
+          new File(subFolder).mkdirs()
+          WriteGEXF(DomainGraphExtractor(rdd), Paths.get(subFolder).toString + "/GEXF.xml")
+        } else {
+          DomainGraphExtractor(rdd).saveAsTextFile(subFolder)
+        }
+      }),
+    "PlainTextExtractor" ->
+      ((rdd: RDD[ArchiveRecord], subFolder: String) => {
+        PlainTextExtractor(rdd).saveAsTextFile(subFolder)}))
+
+    if (!(extractors contains args.extractor())) {
+      log.error(args.extractor() + " not supported. The following extractors are supported: ")
+      extractors foreach { tuple => log.error(tuple._1) }
+      System.exit(1)
+    }
+
+    args.input() foreach { f =>
+      if (!Files.exists(Paths.get(f))) {
+      log.error(f + " not found")
+      System.exit(1)
+    }}
+
+    if (Files.exists(Paths.get(args.output()))) {
+      log.error(args.output() + " already exists")
+      System.exit(1)
+    }
 
     val conf = new SparkConf().setAppName(args.extractor() + " extractor")
     conf.set("spark.driver.allowMultipleContexts", "true")
     val sc = new SparkContext(conf)
+    val extractFunction: (RDD[ArchiveRecord], String) => Any =
+      extractors get args.extractor() match {
+      case Some(func) => func
+      case None =>
+        throw new InternalError()
+    }
 
-    var archive = RecordLoader.loadArchives(args.input(), sc)
-
-    args.input() match {
-      case "domainFreq" =>
-        DomainFrequencyExtractor(archive).saveAsTextFile(args.output())
-      case "domainGraph" =>
-        DomainGraphExtractor(archive).saveAsTextFile(args.output())
-      case "plainText" =>
-        PlainTextExtractor(archive).saveAsTextFile(args.output())
-      case _ => log.error(args.extractor() + " not supported")
+    args.input() foreach { f =>
+      var archive = RecordLoader.loadArchives(f, sc)
+      extractFunction(archive, Paths.get(args.output(), Paths.get(f).getFileName.toString).toString)
     }
   }
 }

--- a/src/main/scala/io/archivesunleashed/app/CommandLineAppRunner.scala
+++ b/src/main/scala/io/archivesunleashed/app/CommandLineAppRunner.scala
@@ -1,0 +1,73 @@
+/*
+ * Archives Unleashed Toolkit (AUT):
+ * An open-source platform for analyzing web archives.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.archivesunleashed.app
+
+import io.archivesunleashed.RecordLoader
+import org.apache.log4j.Logger
+import org.apache.spark.{SparkConf, SparkContext}
+import org.rogach.scallop.ScallopConf
+
+/* Usage:
+ *
+ * PATH_TO_SPARK 
+ *   --class io.archivesunleashed.app.CommandLineAppRunner 
+ *   PATH_TO_AUT_JAR
+ *   EXTRACTOR
+ *   INPUT_FILE
+ *   OUTPUT_DIRECTORY
+ *   
+ * where EXTRACTOR is one of domainFreq, domainGraph or plainText
+ */
+
+object CommandLineAppRunner {
+  var log = Logger.getLogger(getClass().getName())
+
+  class Conf(args: Seq[String]) extends ScallopConf(args) {
+    mainOptions = Seq(input, output)
+    var extractor = opt[String](descr =
+      "extractor, one of domainFreq, domainGraph or plainText", required = true)
+    val input = opt[String](descr = "input path", required = true)
+    val output = opt[String](descr = "output path", required = true)
+    verify()
+  }
+
+  def main(argv: Array[String]): Unit = {
+    print(argv(0))
+    var args = new Conf(argv)
+
+    log.info("Extractor: " + args.extractor())
+    log.info("Input: " + args.input())
+    log.info("Output: " + args.output())
+
+    val conf = new SparkConf().setAppName(args.extractor() + " extractor")
+    conf.set("spark.driver.allowMultipleContexts", "true")
+    val sc = new SparkContext(conf)
+
+    var archive = RecordLoader.loadArchives(args.input(), sc)
+
+    args.input() match {
+      case "domainFreq" =>
+        DomainFrequencyExtractor(archive).saveAsTextFile(args.output())
+      case "domainGraph" =>
+        DomainGraphExtractor(archive).saveAsTextFile(args.output())
+      case "plainText" =>
+        PlainTextExtractor(archive).saveAsTextFile(args.output())
+      case _ => log.error(args.extractor() + " not supported")
+    }
+  }
+}

--- a/src/main/scala/io/archivesunleashed/app/DomainFrequencyExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/DomainFrequencyExtractor.scala
@@ -17,14 +17,9 @@
 
 package io.archivesunleashed.app
 
-import java.nio.file.Path
-
 import io.archivesunleashed._
 import io.archivesunleashed.matchbox.ExtractDomain
-import org.apache.log4j.Logger
-import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.rdd.RDD
-import org.rogach.scallop._
 
 object DomainFrequencyExtractor {
   def apply(records: RDD[ArchiveRecord]) = {

--- a/src/main/scala/io/archivesunleashed/app/DomainFrequencyExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/DomainFrequencyExtractor.scala
@@ -1,0 +1,36 @@
+/*
+ * Archives Unleashed Toolkit (AUT):
+ * An open-source platform for analyzing web archives.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.archivesunleashed.app
+
+import java.nio.file.Path
+
+import io.archivesunleashed._
+import io.archivesunleashed.matchbox.ExtractDomain
+import org.apache.log4j.Logger
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.rdd.RDD
+import org.rogach.scallop._
+
+object DomainFrequencyExtractor {
+  def apply(records: RDD[ArchiveRecord]) = {
+      records
+        .keepValidPages()
+        .map(r => ExtractDomain(r.getUrl))
+        .countItems()
+  }
+}

--- a/src/main/scala/io/archivesunleashed/app/DomainGraphExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/DomainGraphExtractor.scala
@@ -19,7 +19,6 @@ package io.archivesunleashed.app
 
 import io.archivesunleashed._
 import io.archivesunleashed.matchbox.{ExtractDomain, ExtractLinks}
-import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.rdd.RDD
 
 object DomainGraphExtractor {

--- a/src/main/scala/io/archivesunleashed/app/DomainGraphExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/DomainGraphExtractor.scala
@@ -1,0 +1,35 @@
+/*
+ * Archives Unleashed Toolkit (AUT):
+ * An open-source platform for analyzing web archives.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.archivesunleashed.app
+
+import io.archivesunleashed._
+import io.archivesunleashed.matchbox.{ExtractDomain, ExtractLinks}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.rdd.RDD
+
+object DomainGraphExtractor {
+  def apply(records: RDD[ArchiveRecord]) = {
+    records
+      .keepValidPages()
+      .map(r => (r.getCrawlDate, ExtractLinks(r.getUrl, r.getContentString)))
+      .flatMap(r => r._2.map(f => (r._1, ExtractDomain(f._1).replaceAll("^\\\\s*www\\\\.", ""), ExtractDomain(f._2).replaceAll("^\\\\s*www\\\\.", ""))))
+      .filter(r => r._2 != "" && r._3 != "")
+      .countItems()
+      .filter(r => r._2 > 5)
+  }
+}

--- a/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
@@ -1,0 +1,31 @@
+/*
+ * Archives Unleashed Toolkit (AUT):
+ * An open-source platform for analyzing web archives.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.archivesunleashed.app
+
+import io.archivesunleashed.{ArchiveRecord, RecordLoader}
+import io.archivesunleashed.matchbox.RemoveHTML
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.rdd.RDD
+
+object PlainTextExtractor {
+  def apply(records: RDD[ArchiveRecord]) = {
+    records
+      .keepValidPages()
+      .map(r => (r.getCrawlDate, r.getDomain, r.getUrl, RemoveHTML(r.getContentString)))
+  }
+}

--- a/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
@@ -17,9 +17,8 @@
 
 package io.archivesunleashed.app
 
-import io.archivesunleashed.{ArchiveRecord, RecordLoader}
+import io.archivesunleashed.ArchiveRecord
 import io.archivesunleashed.matchbox.RemoveHTML
-import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.rdd.RDD
 
 object PlainTextExtractor {

--- a/src/test/scala/io/archivesunleashed/app/DomainGraphExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/DomainGraphExtractorTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Archives Unleashed Toolkit (AUT):
+ * An open-source platform for analyzing web archives.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.archivesunleashed.app
+
+import com.google.common.io.Resources
+import io.archivesunleashed.RecordLoader
+import org.apache.spark.{SparkConf, SparkContext}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfter, FunSuite}
+
+@RunWith(classOf[JUnitRunner])
+class DomainGraphExtractorTest extends FunSuite with BeforeAndAfter {
+  private val arcPath = Resources.getResource("warc/example.warc.gz").getPath
+  private var sc: SparkContext = _
+  private val master = "local[4]"
+  private val appName = "example-spark"
+
+  before {
+    val conf = new SparkConf()
+      .setMaster(master)
+      .setAppName(appName)
+    conf.set("spark.driver.allowMultipleContexts", "true")
+    sc = new SparkContext(conf)
+  }
+
+  test("extract domain graph in RDD with UDF") {
+    val examplerdd = RecordLoader.loadArchives(arcPath, sc)
+    var domainGraph = DomainGraphExtractor.apply(examplerdd).collect()
+
+    assert(domainGraph.length == 9)
+
+    assert(domainGraph(0)._1._1 == "20080430")
+    assert(domainGraph(0)._1._2 == "www.archive.org")
+    assert(domainGraph(0)._1._3 == "www.archive.org")
+    assert(domainGraph(0)._2 == 305)
+  }
+
+  after {
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+}

--- a/src/test/scala/io/archivesunleashed/app/PlainTextExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/PlainTextExtractorTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Archives Unleashed Toolkit (AUT):
+ * An open-source platform for analyzing web archives.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writi             ng, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.archivesunleashed.app
+
+import com.google.common.io.Resources
+import io.archivesunleashed.RecordLoader
+import org.apache.spark.{SparkConf, SparkContext}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfter, FunSuite}
+
+@RunWith(classOf[JUnitRunner])
+class PlainTextExtractorTest extends FunSuite with BeforeAndAfter {
+  private val arcPath = Resources.getResource("warc/example.warc.gz").getPath
+  private var sc: SparkContext = _
+  private val master = "local[4]"
+  private val appName = "example-spark"
+
+  before {
+    val conf = new SparkConf()
+      .setMaster(master)
+      .setAppName(appName)
+    conf.set("spark.driver.allowMultipleContexts", "true")
+    sc = new SparkContext(conf)
+  }
+
+  test("extract plain text from html in RDD with UDF") {
+    val examplerdd = RecordLoader.loadArchives(arcPath, sc)
+    var plainText = PlainTextExtractor.apply(examplerdd).collect()
+
+    assert(plainText.length == 135)
+    assert(plainText(0)._1 == "20080430")
+    assert(plainText(0)._2 == "www.archive.org")
+    assert(plainText(0)._3 == "http://www.archive.org/")
+    assert(plainText(0)._4 == "HTTP/1.1 200 OK Date: Wed, 30 Apr 2008 20:48:25 GMT Server: Apache/2.0.54 (Ubuntu) PHP/5.0.5-2ubuntu1.4 mod_ssl/2.0.54 OpenSSL/0.9.7g Last-Modified: Wed, 09 Jan 2008 23:18:29 GMT ETag: \"47ac-16e-4f9e5b40\" Accept-Ranges: bytes Content-Length: 366 Connection: close Content-Type: text/html; charset=UTF-8 Please visit our website at: http://www.archive.org")
+
+  }
+
+  after {
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+}

--- a/src/test/scala/io/archivesunleashed/app/PlainTextExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/PlainTextExtractorTest.scala
@@ -48,7 +48,6 @@ class PlainTextExtractorTest extends FunSuite with BeforeAndAfter {
     assert(plainText(0)._2 == "www.archive.org")
     assert(plainText(0)._3 == "http://www.archive.org/")
     assert(plainText(0)._4 == "HTTP/1.1 200 OK Date: Wed, 30 Apr 2008 20:48:25 GMT Server: Apache/2.0.54 (Ubuntu) PHP/5.0.5-2ubuntu1.4 mod_ssl/2.0.54 OpenSSL/0.9.7g Last-Modified: Wed, 09 Jan 2008 23:18:29 GMT ETag: \"47ac-16e-4f9e5b40\" Accept-Ranges: bytes Content-Length: 366 Connection: close Content-Type: text/html; charset=UTF-8 Please visit our website at: http://www.archive.org")
-
   }
 
   after {


### PR DESCRIPTION
Implement DomainFrequency, DomainGraph and PlainText extractor that can be run via command line in spark-submit, along with their tests

* * *

**GitHub issue(s)**: #195 


# What does this Pull Request do?

This pull request implement DomainFrequency, DomainGraph and PlainText extractor that can be run via command line in spark-submit, along with their tests. Job can be submitted like so:

`./spark-2.3.0-bin-hadoop2.7/bin/spark-submit --class io.archivesunleashed.app.CommandLineAppRunner ./aut/target/aut-0.16.1-SNAPSHOT-fatjar.jar --extractor EXTRACTOR --input ./aut/src/test/resources/warc/example.warc.gz --output OUTPUT`

where EXTRACTOR is one of domainFreq, domainGraph or plainText, and OUTPUT is the directory to write output to.

# How should this be tested?

`mvn install` to build the executable and run tests. There are three new tests that test each one of the operations added.

Execute the above command in command line, substituting path to output, Spark and AUT executable as necessary.

# Additional Notes:

* Does this change require documentation to be updated?

Possibly yes, because the jar file now has additional main function that can be invoked directly.

* Does this change add any new dependencies?

Yes, org.rogach.scallop is used to parse command line arguments.

* Could this change or impact execution of existing code?

No, because this pull request only creates new files.

# Interested parties

Tag (@ mention) interested parties.

Thanks in advance for your help with the Archives Unleashed Toolkit!
