### PR TITLE
Add Extract Image Details API

### DIFF
--- a/src/main/scala/io/archivesunleashed/DataFrameLoader.scala
+++ b/src/main/scala/io/archivesunleashed/DataFrameLoader.scala
@@ -21,7 +21,7 @@ class DataFrameLoader(sc: SparkContext) {
   }
 
   /** Create a dataframe with (image url, type, width, height, md5, raw bytes) pairs */
-  def extractImageDetails(path: String): DataFrame = {
+  def extractImages(path: String): DataFrame = {
     RecordLoader.loadArchives(path, sc)
       .extractImageDetailsDF()
   }

--- a/src/main/scala/io/archivesunleashed/DataFrameLoader.scala
+++ b/src/main/scala/io/archivesunleashed/DataFrameLoader.scala
@@ -19,4 +19,10 @@ class DataFrameLoader(sc: SparkContext) {
   	RecordLoader.loadArchives(path, sc)
   		.extractImageLinksDF()
   }
+
+  /** Create a dataframe with (image url, type, width, height, md5, raw bytes) pairs */
+  def extractImageDetails(path: String): DataFrame = {
+    RecordLoader.loadArchives(path, sc)
+      .extractImageDetailsDF()
+  }
 }

--- a/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
@@ -16,13 +16,6 @@
  */
 package io.archivesunleashed.matchbox
 
-import java.io.ByteArrayInputStream
-import java.io.IOException;
-import org.apache.tika.metadata.Metadata;
-import org.apache.tika.parser.AutoDetectParser;
-import org.apache.tika.parser.ParseContext;
-import org.apache.tika.sax.BodyContentHandler;
-
 /** Information about an image. e.g. width, height*/
 class ImageDetails(w: Int, h: Int) {
   val width: Int = w
@@ -36,32 +29,10 @@ object ExtractImageDetails {
    * @param bytes the raw bytes of the image
    * @return A tuple containing the width and height of the image
   */
-  def apply(url: String, mimetype: String, bytes: Array[Byte]): ImageDetails = {
-    val inputStream = new ByteArrayInputStream(bytes);
-    val handler = new BodyContentHandler();
-    val metadata = new Metadata();
-    val pcontext = new ParseContext();
-
-    val parser = new AutoDetectParser();
-    parser.parse(inputStream, handler, metadata, pcontext);
- 
-    var widthField = "tiff:ImageWidth";
-    var heightField = "tiff:ImageLength";
-
-    var width = 0;
-    var height= 0;
-    try {
-      // all properties in metadata are type string
-      // the width and height should be valid integers representing
-      // width and height in pixels
-      width = metadata.get(widthField).toInt;
-      height = metadata.get(heightField).toInt;
-    } catch {
-      // should not happen
-      case e: NumberFormatException => {
-        throw new IOException("Invalid image dimensions")
-      }
-    }
+  def apply(bytes: Array[Byte]): ImageDetails = {
+    val dimensions = ComputeImageSize(bytes);
+    val width = dimensions._1
+    val height = dimensions._2
     return new ImageDetails(width, height)
   }
 }

--- a/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
@@ -26,34 +26,34 @@ import org.apache.tika.sax.BodyContentHandler;
 
 /** Information about an image. e.g. width, height*/
 class ImageDetails(w: String, h: String) {
-	val width: String = w
-	val height: String = h
+  val width: String = w
+  val height: String = h
 }
 
 /** Extracts image details given raw bytes (using Apache Tika) */
 object ExtractImageDetails {
 
-	/**
-	 * @param bytes the raw bytes of the image
-	 * @return A tuple containing the width and height of the image
-	*/
-	def apply(url: String, mimetype: String, bytes: Array[Byte]): ImageDetails = {
-		val inputStream = new ByteArrayInputStream(bytes)
-		val handler = new BodyContentHandler();
-  	val metadata = new Metadata();
-  	val pcontext = new ParseContext();
+  /**
+   * @param bytes the raw bytes of the image
+   * @return A tuple containing the width and height of the image
+  */
+  def apply(url: String, mimetype: String, bytes: Array[Byte]): ImageDetails = {
+    val inputStream = new ByteArrayInputStream(bytes)
+    val handler = new BodyContentHandler();
+    val metadata = new Metadata();
+    val pcontext = new ParseContext();
 
-  	// different parsers for different file formats
-  	if ((mimetype != null && mimetype.contains("image/jpeg")) || url.endsWith("jpg") || url.endsWith("jpeg")) {
-  		val parser = new JpegParser();
-  		val results = parser.parse(inputStream, handler, metadata, pcontext)
-  	} else if ((mimetype != null && mimetype.contains("image/tiff")) || url.endsWith("tiff")) {
-  		val parser = new TiffParser();
-  		val results = parser.parse(inputStream, handler, metadata, pcontext)
-  	} else {
-  		val parser = new ImageParser();
-			val results = parser.parse(inputStream, handler, metadata, pcontext)
+    // different parsers for different image formats
+    if ((mimetype != null && mimetype.contains("image/jpeg")) || url.endsWith("jpg") || url.endsWith("jpeg")) {
+      val parser = new JpegParser();
+      val results = parser.parse(inputStream, handler, metadata, pcontext)
+    } else if ((mimetype != null && mimetype.contains("image/tiff")) || url.endsWith("tiff")) {
+      val parser = new TiffParser();
+      val results = parser.parse(inputStream, handler, metadata, pcontext)
+    } else {
+      val parser = new ImageParser();
+      val results = parser.parse(inputStream, handler, metadata, pcontext)
     }
     return new ImageDetails(metadata.get("Image Width"), metadata.get("Image Height"))
-	}
+  }
 }

--- a/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
@@ -43,6 +43,7 @@ object ExtractImageDetails {
   	val metadata = new Metadata();
   	val pcontext = new ParseContext();
 
+  	// different parsers for different file formats
   	if ((mimetype != null && mimetype.contains("image/jpeg")) || url.endsWith("jpg") || url.endsWith("jpeg")) {
   		val parser = new JpegParser();
   		val results = parser.parse(inputStream, handler, metadata, pcontext)

--- a/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
@@ -19,7 +19,7 @@ package io.archivesunleashed.matchbox
 import java.io.ByteArrayInputStream
 import java.io.IOException;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.parser.image.ImageParser;
+import org.apache.tika.parser.image.{ImageParser, TiffParser};
 import org.apache.tika.parser.jpeg.JpegParser;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.sax.BodyContentHandler;
@@ -42,8 +42,12 @@ object ExtractImageDetails {
 		val handler = new BodyContentHandler();
   	val metadata = new Metadata();
   	val pcontext = new ParseContext();
+
   	if ((mimetype != null && mimetype.contains("image/jpeg")) || url.endsWith("jpg") || url.endsWith("jpeg")) {
   		val parser = new JpegParser();
+  		val results = parser.parse(inputStream, handler, metadata, pcontext)
+  	} else if ((mimetype != null && mimetype.contains("image/tiff")) || url.endsWith("tiff")) {
+  		val parser = new TiffParser();
   		val results = parser.parse(inputStream, handler, metadata, pcontext)
   	} else {
   		val parser = new ImageParser();

--- a/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
@@ -1,0 +1,54 @@
+/*
+ * Archives Unleashed Toolkit (AUT):
+ * An open-source platform for analyzing web archives.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.archivesunleashed.matchbox
+
+import java.io.ByteArrayInputStream
+import java.io.IOException;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.parser.image.ImageParser;
+import org.apache.tika.parser.jpeg.JpegParser;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.sax.BodyContentHandler;
+
+/** Information about an image. e.g. width, height*/
+class ImageDetails(w: String, h: String) {
+	val width: String = w
+	val height: String = h
+}
+
+/** Extracts image details given raw bytes (using Apache Tika) */
+object ExtractImageDetails {
+
+	/**
+	 * @param bytes the raw bytes of the image
+	 * @return A tuple containing the width and height of the image
+	*/
+	def apply(url: String, bytes: Array[Byte]): ImageDetails = {
+		val inputStream = new ByteArrayInputStream(bytes)
+		val handler = new BodyContentHandler();
+      	val metadata = new Metadata();
+      	val pcontext = new ParseContext();
+      	if (url.endsWith("jpg") || url.endsWith("jpeg")) {
+      		val parser = new JpegParser();
+      		val results = parser.parse(inputStream, handler, metadata, pcontext)
+      	} else {
+      		val parser = new ImageParser();
+			val results = parser.parse(inputStream, handler, metadata, pcontext)
+      	}
+      	return new ImageDetails(metadata.get("Image Width"), metadata.get("Image Height"))
+	}
+}

--- a/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
@@ -37,18 +37,18 @@ object ExtractImageDetails {
 	 * @param bytes the raw bytes of the image
 	 * @return A tuple containing the width and height of the image
 	*/
-	def apply(url: String, bytes: Array[Byte]): ImageDetails = {
+	def apply(url: String, mimetype: String, bytes: Array[Byte]): ImageDetails = {
 		val inputStream = new ByteArrayInputStream(bytes)
 		val handler = new BodyContentHandler();
-      	val metadata = new Metadata();
-      	val pcontext = new ParseContext();
-      	if (url.endsWith("jpg") || url.endsWith("jpeg")) {
-      		val parser = new JpegParser();
-      		val results = parser.parse(inputStream, handler, metadata, pcontext)
-      	} else {
-      		val parser = new ImageParser();
+  	val metadata = new Metadata();
+  	val pcontext = new ParseContext();
+  	if ((mimetype != null && mimetype.contains("image/jpeg")) || url.endsWith("jpg") || url.endsWith("jpeg")) {
+  		val parser = new JpegParser();
+  		val results = parser.parse(inputStream, handler, metadata, pcontext)
+  	} else {
+  		val parser = new ImageParser();
 			val results = parser.parse(inputStream, handler, metadata, pcontext)
-      	}
-      	return new ImageDetails(metadata.get("Image Width"), metadata.get("Image Height"))
+    }
+    return new ImageDetails(metadata.get("Image Width"), metadata.get("Image Height"))
 	}
 }

--- a/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/ExtractImageDetails.scala
@@ -16,10 +16,21 @@
  */
 package io.archivesunleashed.matchbox
 
+import java.security.MessageDigest
+import java.util.Base64
+import java.nio.charset.StandardCharsets
+import org.apache.commons.codec.binary.Hex
+
+
 /** Information about an image. e.g. width, height*/
-class ImageDetails(w: Int, h: Int) {
-  val width: Int = w
-  val height: Int = h
+class ImageDetails(imageUrl: String, imageType: String, bytes: Array[Byte]) {
+  val dimensions = ComputeImageSize(bytes);
+  val width = dimensions._1
+  val height = dimensions._2
+  val url: String = imageUrl
+  val mimeType: String = imageType
+  val hash: String = new String(Hex.encodeHex(MessageDigest.getInstance("MD5").digest(bytes)))
+  val body: String = Base64.getEncoder.encodeToString(bytes)
 }
 
 /** Extracts image details given raw bytes (using Apache Tika) */
@@ -29,10 +40,7 @@ object ExtractImageDetails {
    * @param bytes the raw bytes of the image
    * @return A tuple containing the width and height of the image
   */
-  def apply(bytes: Array[Byte]): ImageDetails = {
-    val dimensions = ComputeImageSize(bytes);
-    val width = dimensions._1
-    val height = dimensions._2
-    return new ImageDetails(width, height)
+  def apply(url: String, mimeType: String, bytes: Array[Byte]): ImageDetails = {
+    return new ImageDetails(url, mimeType, bytes)
   }
 }

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -134,8 +134,8 @@ package object archivesunleashed {
         .map(t => Row(t._1, t._2))
 
       val schema = new StructType()
-        .add(StructField("Src", StringType, true))
-        .add(StructField("ImageUrl", StringType, true))
+        .add(StructField("src", StringType, true))
+        .add(StructField("image_url", StringType, true))
 
       val sqlContext = SparkSession.builder();
       sqlContext.getOrCreate().createDataFrame(records, schema)
@@ -151,12 +151,12 @@ package object archivesunleashed {
         .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6))
       
       val schema = new StructType()
-        .add(StructField("Url", StringType, true))
-        .add(StructField("Type", StringType, true))
-        .add(StructField("Width", IntegerType, true))
-        .add(StructField("Height", IntegerType, true))
-        .add(StructField("MD5", StringType, true))
-        .add(StructField("Body", StringType, true))
+        .add(StructField("url", StringType, true))
+        .add(StructField("mime_type", StringType, true))
+        .add(StructField("width", IntegerType, true))
+        .add(StructField("height", IntegerType, true))
+        .add(StructField("md5", StringType, true))
+        .add(StructField("bytes", StringType, true))
 
       val sqlContext = SparkSession.builder();
       sqlContext.getOrCreate().createDataFrame(records, schema)

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -152,8 +152,8 @@ package object archivesunleashed {
       val schema = new StructType()
         .add(StructField("Url", StringType, true))
         .add(StructField("Type", StringType, true))
-        .add(StructField("Width", StringType, true))
-        .add(StructField("Height", StringType, true))
+        .add(StructField("Width", IntegerType, true))
+        .add(StructField("Height", IntegerType, true))
         .add(StructField("MD5", StringType, true))
         .add(StructField("Bytes", BinaryType, true))
 

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -144,13 +144,13 @@ package object archivesunleashed {
       val records = rdd
         .keepImages()
         .map(r => {
-          val details = ExtractImageDetails(r.getUrl, r.getImageBytes)
+          val details = ExtractImageDetails(r.getUrl, r.getMimeType, r.getImageBytes)
           (r.getUrl, r.getMimeType, details.width, details.height, ComputeMD5(r.getImageBytes), r.getImageBytes)
         })
         .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6))
       
       val schema = new StructType()
-        .add(StructField("ImageUrl", StringType, true))
+        .add(StructField("Url", StringType, true))
         .add(StructField("Type", StringType, true))
         .add(StructField("Width", StringType, true))
         .add(StructField("Height", StringType, true))

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -144,7 +144,7 @@ package object archivesunleashed {
       val records = rdd
         .keepImages()
         .map(r => {
-          val details = ExtractImageDetails(r.getUrl, r.getMimeType, r.getImageBytes)
+          val details = ExtractImageDetails(r.getImageBytes)
           (r.getUrl, r.getMimeType, details.width, details.height, ComputeMD5(r.getImageBytes), r.getImageBytes)
         })
         .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6))

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -141,6 +141,7 @@ package object archivesunleashed {
       sqlContext.getOrCreate().createDataFrame(records, schema)
     }
 
+    /* Extract image bytes and metadata*/
     def extractImageDetailsDF(): DataFrame = {
       val records = rdd
         .keepImages()

--- a/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
@@ -40,7 +40,7 @@ class ExtractImageDetailsTest extends FunSuite with BeforeAndAfter {
     sc = new SparkContext(conf)
   }
 
-  test("Fetch image links") {
+  test("Fetch image") {
     val df = RecordLoader.loadArchives(arcPath, sc)
       .extractImageDetailsDF()
 

--- a/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
@@ -1,0 +1,69 @@
+/*
+ * Archives Unleashed Toolkit (AUT):
+ * An open-source platform for analyzing web archives.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.archivesunleashed
+
+import com.google.common.io.Resources
+import io.archivesunleashed.df._
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
+import org.apache.spark.{SparkConf, SparkContext}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfter, FunSuite}
+
+@RunWith(classOf[JUnitRunner])
+class ExtractImageDetailsTest extends FunSuite with BeforeAndAfter {
+  private val arcPath = Resources.getResource("arc/example.arc.gz").getPath
+  private val master = "local[4]"
+  private val appName = "example-df"
+  private var sc: SparkContext = _
+
+  before {
+    val conf = new SparkConf()
+      .setMaster(master)
+      .setAppName(appName)
+    sc = new SparkContext(conf)
+  }
+
+  test("Fetch image links") {
+    val df = RecordLoader.loadArchives(arcPath, sc)
+      .extractImageDetailsDF()
+
+    // We need this in order to use the $-notation
+    val spark = SparkSession.builder().master("local").getOrCreate()
+    import spark.implicits._
+
+    val extracted = df.select($"ImageUrl", $"Type", $"Width", $"Height", $"MD5")
+      .orderBy(desc("MD5")).head(2).toList
+    assert(extracted.size == 2)
+    assert("http://www.archive.org/images/LOCLogoSmall.jpg" == extracted(0)(0))
+    assert("image/jpeg" == extracted(0)(1))
+    assert("275 pixels" == extracted(0)(2))
+    assert("300 pixels" == extracted(0)(3))
+    assert("http://www.archive.org/images/lma.jpg" == extracted(1)(0))
+    assert("image/jpeg" == extracted(1)(1))
+    assert("215 pixels" == extracted(1)(2))
+    assert("71 pixels" == extracted(1)(3))
+  }
+
+  after {
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+}

--- a/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
@@ -53,12 +53,12 @@ class ExtractImageDetailsTest extends FunSuite with BeforeAndAfter {
     assert(extracted.size == 2)
     assert("http://www.archive.org/images/LOCLogoSmall.jpg" == extracted(0)(0))
     assert("image/jpeg" == extracted(0)(1))
-    assert("275 pixels" == extracted(0)(2))
-    assert("300 pixels" == extracted(0)(3))
+    assert(275 == extracted(0)(2))
+    assert(300 == extracted(0)(3))
     assert("http://www.archive.org/images/lma.jpg" == extracted(1)(0))
     assert("image/jpeg" == extracted(1)(1))
-    assert("215 pixels" == extracted(1)(2))
-    assert("71 pixels" == extracted(1)(3))
+    assert(215 == extracted(1)(2))
+    assert(71 == extracted(1)(3))
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
@@ -48,7 +48,7 @@ class ExtractImageDetailsTest extends FunSuite with BeforeAndAfter {
     val spark = SparkSession.builder().master("local").getOrCreate()
     import spark.implicits._
 
-    val extracted = df.select($"ImageUrl", $"Type", $"Width", $"Height", $"MD5")
+    val extracted = df.select($"Url", $"Type", $"Width", $"Height", $"MD5")
       .orderBy(desc("MD5")).head(2).toList
     assert(extracted.size == 2)
     assert("http://www.archive.org/images/LOCLogoSmall.jpg" == extracted(0)(0))

--- a/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
@@ -51,14 +51,14 @@ class ExtractImageDetailsTest extends FunSuite with BeforeAndAfter {
     val extracted = df.select($"Url", $"Type", $"Width", $"Height", $"MD5")
       .orderBy(desc("MD5")).head(2).toList
     assert(extracted.size == 2)
-    assert("http://www.archive.org/images/LOCLogoSmall.jpg" == extracted(0)(0))
-    assert("image/jpeg" == extracted(0)(1))
-    assert(275 == extracted(0)(2))
-    assert(300 == extracted(0)(3))
-    assert("http://www.archive.org/images/lma.jpg" == extracted(1)(0))
+    assert("http://www.archive.org/images/mediatype_movies.gif" == extracted(0)(0))
+    assert("image/gif" == extracted(0)(1))
+    assert(21 == extracted(0)(2))
+    assert(21 == extracted(0)(3))
+    assert("http://www.archive.org/images/LOCLogoSmall.jpg" == extracted(1)(0))
     assert("image/jpeg" == extracted(1)(1))
-    assert(215 == extracted(1)(2))
-    assert(71 == extracted(1)(3))
+    assert(275 == extracted(1)(2))
+    assert(300 == extracted(1)(3))
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
@@ -48,8 +48,8 @@ class ExtractImageDetailsTest extends FunSuite with BeforeAndAfter {
     val spark = SparkSession.builder().master("local").getOrCreate()
     import spark.implicits._
 
-    val extracted = df.select($"Url", $"Type", $"Width", $"Height", $"MD5")
-      .orderBy(desc("MD5")).head(2).toList
+    val extracted = df.select($"url", $"mime_type", $"width", $"height", $"md5")
+      .orderBy(desc("md5")).head(2).toList
     assert(extracted.size == 2)
     assert("http://www.archive.org/images/mediatype_movies.gif" == extracted(0)(0))
     assert("image/gif" == extracted(0)(1))

--- a/src/test/scala/io/archivesunleashed/df/ExtractImageLinksTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractImageLinksTest.scala
@@ -48,7 +48,7 @@ class ExtractImageLinksTest extends FunSuite with BeforeAndAfter {
     val spark = SparkSession.builder().master("local").getOrCreate()
     import spark.implicits._
 
-    val extracted = df.select($"Src".as("Domain"), $"ImageUrl".as("Image"))
+    val extracted = df.select($"src".as("Domain"), $"image_url".as("Image"))
       .orderBy(desc("Image")).head(2).toList
     assert(extracted.size == 2)
     assert("http://www.archive.org/index.php" == extracted(0)(0))


### PR DESCRIPTION
* * *

**GitHub issue(s)**:

* #220

# What does this Pull Request do?

* Add DataFrame API to extract (image url, type, width, height, md5, raw bytes) pairs in `WARRecord`
* Add an entry point from DataframeLoader
* Add a test for the API

# How should this be tested?

* `mvn clean install`
* `mvn -Dtest=ExtractImageDetailsTest test`

# Additional Notes:
* `mvn clean install` builds successfully and all tests pass

# Interested parties
@lintool @ruebot 
