### PR TITLE
Get rid of 'filesystem-root relative reference' warning.

### DIFF
--- a/src/main/assembly/python.xml
+++ b/src/main/assembly/python.xml
@@ -7,7 +7,7 @@
   <fileSets>
     <fileSet>
       <directory>src/main/python/aut/</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
     </fileSet>
   </fileSets>
 </assembly>


### PR DESCRIPTION
# What does this Pull Request do?

Resolves this build warning:
```
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /
```

# How should this be tested?

PySpark support should work just fine.

# Interested parties

@ianmilligan1 when you have time, can you verify we're good? No rush on this one.