### PR TITLE
Add support for full_text in tweets; resolve #192.

### DIFF
--- a/src/main/scala/io/archivesunleashed/util/TweetUtils.scala
+++ b/src/main/scala/io/archivesunleashed/util/TweetUtils.scala
@@ -36,6 +36,8 @@ object TweetUtils {
     def createdAt(): String = try { (tweet \ "created_at").extract[String] } catch { case e: Exception => ""}
     /** Get the status text. */
     def text(): String = try { (tweet \ "text").extract[String] } catch { case e: Exception => ""}
+    /** Get the full_text. */
+    def fullText(): String = try { (tweet \ "full_text").extract[String] } catch { case e: Exception => ""}
     /** Get the language code (ISO 639-1). */
     def lang: String = try { (tweet \ "lang").extract[String] } catch { case e: Exception => ""}
     /** Get the username of the user who wrote the status. */

--- a/src/test/scala/io/archivesunleashed/util/TweetUtilsTest.scala
+++ b/src/test/scala/io/archivesunleashed/util/TweetUtilsTest.scala
@@ -31,6 +31,7 @@ class TweetUtilsTest extends FunSuite {
     var tweet:org.json4s.JValue = parse("""{"id_str":"123",
       "created_at":"20150702",
       "text": "some text",
+      "full_text": "some full text",
       "lang": "en",
       "user": {
       "screen_name": "twitteruser",
@@ -42,6 +43,7 @@ class TweetUtilsTest extends FunSuite {
     assert(tweet.id() == "123")
     assert(tweet.createdAt() == "20150702")
     assert(tweet.text() == "some text")
+    assert(tweet.fullText() == "some full text")
     assert(tweet.lang == "en")
     assert(tweet.username() == "twitteruser")
     assert(tweet.isVerifiedUser())
@@ -53,6 +55,7 @@ class TweetUtilsTest extends FunSuite {
     var tweet:org.json4s.JValue = parse("""{"id_str": null,
       "created_at":null,
       "text": null,
+      "full_text": null,
       "lang": null,
       "user": {
       "screen_name": null,
@@ -64,6 +67,7 @@ class TweetUtilsTest extends FunSuite {
       assert(tweet.id() == null)
       assert(tweet.createdAt() == null)
       assert(tweet.text() == null)
+      assert(tweet.fullText() == null)
       assert(tweet.lang == null)
       assert(tweet.username() == null)
       assert(!tweet.isVerifiedUser())


### PR DESCRIPTION
**GitHub issue(s)**:
#192

# What does this Pull Request do?

Add support to the Tweet utility to use `full_text` from tweets.

# How should this be tested?

I did this with Apache Spark 2.3.1:

```
scala> :paste
// Entering paste mode (ctrl-D to finish)

import io.archivesunleashed._
import io.archivesunleashed.matchbox._
import io.archivesunleashed.util.TweetUtils._

// Load tweets from HDFS
val tweets = RecordLoader.loadTweets("/path/to/replies.jsonl", sc)

// Count them
tweets.count()

// Extract some fields
val r = tweets.map(tweet => (tweet.id, tweet.createdAt, tweet.username, tweet.text, tweet.fullText, tweet.lang,
                             tweet.isVerifiedUser, tweet.followerCount, tweet.friendCount))

// Take a sample of 10 on console
r.take(10)

// Exiting paste mode, now interpreting.

import io.archivesunleashed._
import io.archivesunleashed.matchbox._
import io.archivesunleashed.util.TweetUtils._
tweets: org.apache.spark.rdd.RDD[org.json4s.JValue] = MapPartitionsRDD[28] at filter at package.scala:65
r: org.apache.spark.rdd.RDD[(String, String, String, String, String, String, Boolean, Int, Int)] = MapPartitionsRDD[29] at map at <console>:50
res1: Array[(String, String, String, String, String, String, Boolean, Int, Int)] = Array((1004742470700322816,Thu Jun 07 15:10:46 +0000 2018,realDonaldTrump,"",When will people start saying, “thank you, Mr. President, for firing James Comey?”,en,true,52543149,46), (1005275688990052352,Sat Jun 09 02:29:36 +0000 2018,love4All_7,"",@realDonaldTrump Pleases look into my brothers case. Miskin Kamara, he's been locked up for 13+ years w...
```

If you want to use the same tweet set, it's [here](https://www.dropbox.com/s/n9usewf7s58k540/replies.jsonl).

# Additional Notes:

Once this is good to go, I'll take care of #194.

# Interested parties

@ianmilligan1 @lintool 