### PR TITLE
Add additional tweet fields to TweetUtils; partially address #194.

### DIFF
--- a/src/main/scala/io/archivesunleashed/util/TweetUtils.scala
+++ b/src/main/scala/io/archivesunleashed/util/TweetUtils.scala
@@ -30,23 +30,49 @@ object TweetUtils {
   implicit class JsonTweet(tweet: JValue) {
     val user = "user"
     implicit lazy val formats = org.json4s.DefaultFormats
-    /** Get Twitter status id. */
+    /** Get tweet id. */
     def id(): String = try { (tweet \ "id_str").extract[String] } catch { case e: Exception => ""}
-    /** Get the date a status was created. */
+    /** Get the date a tweet was created. */
     def createdAt(): String = try { (tweet \ "created_at").extract[String] } catch { case e: Exception => ""}
-    /** Get the status text. */
+    /** Get the tweet text. */
     def text(): String = try { (tweet \ "text").extract[String] } catch { case e: Exception => ""}
-    /** Get the full_text. */
+    /** Get the tweet full_text. */
     def fullText(): String = try { (tweet \ "full_text").extract[String] } catch { case e: Exception => ""}
-    /** Get the language code (ISO 639-1). */
+    /** Get the tweet language code (ISO 639-1). */
     def lang: String = try { (tweet \ "lang").extract[String] } catch { case e: Exception => ""}
-    /** Get the username of the user who wrote the status. */
+    /** Get the username of the user who wrote the tweet. */
     def username(): String = try { (tweet \ user \ "screen_name").extract[String] } catch { case e: Exception => ""}
-    /** Check if user of status is "verified" (true or false). */
+    /** Check if user of tweet is "verified" (true or false). */
     def isVerifiedUser(): Boolean = try { (tweet \ user \ "verified").extract[Boolean] } catch { case e: Exception => false}
-    /** Get the number of followers the user has. */
+    /** Get the number of followers the user has at the time of tweet. */
     def followerCount: Int = try { (tweet \ user \ "followers_count").extract[Int] } catch { case e: Exception => 0}
-    /** Get the number of friends (people the person follows) of the user. */
+    /** Get the number of friends (people the person follows) of the user at the time of the tweet. */
     def friendCount: Int = try { (tweet \ user \ "friends_count").extract[Int] } catch { case e: Exception => 0}
+    /** Get retweet count of a tweet. */
+    def retweetCount: Int = try { (tweet \ "retweet_count").extract[Int] } catch { case e: Exception => 0}
+    /** Get favorite count of a tweet. */
+    def favoriteCount: Int = try { (tweet \ "favorite_count").extract[Int] } catch { case e: Exception => 0}
+    /** Get the tweet id of a tweet that that tweet was in reply to. */
+    def inReplyToStatusId(): String = try { (tweet \ "in_reply_to_status_id_str").extract[String] } catch { case e: Exception => ""}
+    /** Get the id of a user that that tweet was in reply to. */
+    def inReplyToUserId(): String = try { (tweet \ "in_reply_to_user_id_str").extract[String] } catch { case e: Exception => ""}
+    /** Get the screen name of a user that that tweet was in reply to. */
+    def inReplyToScreenName(): String = try { (tweet \ "in_reply_to_screen_name").extract[String] } catch { case e: Exception => ""}
+    /** Get source (application used) of a tweet. */
+    def source(): String = try { (tweet \ "source").extract[String] } catch { case e: Exception => ""}
+    /** Check is a user's tweets are protected (true or false). */
+    def isUserProtected(): Boolean = try { (tweet \ user \ "protected").extract[Boolean] } catch { case e: Exception => false}
+    /** Get the profile image url of a user. */
+    def profileImageUrl(): String = try { (tweet \ user \ "profile_image_url").extract[String] } catch { case e: Exception => ""}
+    /** Get the user's profile description. */
+    def profileDescription(): String = try { (tweet \ user \ "description").extract[String] } catch { case e: Exception => ""}
+    /** Get the user's provided location. */
+    def profileLocation(): String = try { (tweet \ user \ "location").extract[String] } catch { case e: Exception => ""}
+    /** Get the user's provided name. */
+    def profileName(): String = try { (tweet \ user \ "name").extract[String] } catch { case e: Exception => ""}
+    /** Get the user's provided url. */
+    def profileUrl(): String = try { (tweet \ user \ "url").extract[String] } catch { case e: Exception => ""}
+    /** Get the user's provided timezone. */
+    def profileTimezone(): String = try { (tweet \ user \ "time_zone").extract[String] } catch { case e: Exception => ""}
   }
 }

--- a/src/test/scala/io/archivesunleashed/util/TweetUtilsTest.scala
+++ b/src/test/scala/io/archivesunleashed/util/TweetUtilsTest.scala
@@ -33,17 +33,45 @@ class TweetUtilsTest extends FunSuite {
       "text": "some text",
       "full_text": "some full text",
       "lang": "en",
+      "retweet_count": 12345,
+      "favorite_count": 98765,
+      "in_reply_to_status_id_str": "12345",
+      "in_reply_to_user_id_str": "5647",
+      "in_reply_to_screen_name": "ianmilligan1",
+      "source": "<a href='http://twitter.com' rel='nofollow'>Twitter Web Client</a>",
       "user": {
       "screen_name": "twitteruser",
       "verified": true,
+      "protected": true,
+      "profile_image_url": "https://pbs.twimg.com/profile_images/988576161797042177/xBrHGaCj_400x400.jpg",
+      "description": "some description",
+      "location": "Detroit, MI",
+      "name": "Nick Ruest",
+      "url": "https://archivesunleashed.org/",
+      "time_zone": "Eastern Time (US & Canada)",
       "followers_count": 45,
       "friends_count": 758}}""")
     val expectedFollowers = 45
     val expectedFriends = 758
+    val expectedRetweetCount = 12345
+    val expectedFavoriteCount = 98765
     assert(tweet.id() == "123")
     assert(tweet.createdAt() == "20150702")
     assert(tweet.text() == "some text")
     assert(tweet.fullText() == "some full text")
+    assert(tweet.retweetCount == expectedRetweetCount)
+    assert(tweet.favoriteCount == expectedFavoriteCount)
+    assert(tweet.inReplyToStatusId() == "12345")
+    assert(tweet.inReplyToUserId() == "5647")
+    assert(tweet.inReplyToScreenName() == "ianmilligan1")
+    assert(tweet.source() == "<a href='http://twitter.com' rel='nofollow'>Twitter Web Client</a>")
+    assert(tweet.isUserProtected())
+    assert(tweet.profileImageUrl() == "https://pbs.twimg.com/profile_images/988576161797042177/xBrHGaCj_400x400.jpg")
+    assert(tweet.profileDescription() == "some description")
+    assert(tweet.profileLocation() == "Detroit, MI")
+    assert(tweet.profileName() == "Nick Ruest")
+    assert(tweet.profileUrl() == "https://archivesunleashed.org/")
+    assert(tweet.profileTimezone() == "Eastern Time (US & Canada)")
     assert(tweet.lang == "en")
     assert(tweet.username() == "twitteruser")
     assert(tweet.isVerifiedUser())
@@ -57,9 +85,22 @@ class TweetUtilsTest extends FunSuite {
       "text": null,
       "full_text": null,
       "lang": null,
+      "retweet_count": null,
+      "favorite_count": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "source": null,
       "user": {
       "screen_name": null,
       "verified" : null,
+      "protected": false,
+      "profile_image_url": null,
+      "description": null,
+      "location": null,
+      "name": null,
+      "url": null,
+      "time_zone": null,
       "followers_count": null,
       "friends_count": null}}""")
     val expected = 0
@@ -73,5 +114,18 @@ class TweetUtilsTest extends FunSuite {
       assert(!tweet.isVerifiedUser())
       assert(tweet.followerCount == expected)
       assert(tweet.friendCount == expected)
+      assert(tweet.retweetCount == expected)
+      assert(tweet.favoriteCount == expected)
+      assert(tweet.inReplyToScreenName() == null)
+      assert(tweet.inReplyToStatusId() == null)
+      assert(tweet.inReplyToUserId() == null)
+      assert(tweet.source() == null)
+      assert(tweet.isUserProtected() == false)
+      assert(tweet.profileImageUrl() == null)
+      assert(tweet.profileDescription() == null)
+      assert(tweet.profileLocation() == null)
+      assert(tweet.profileName() == null)
+      assert(tweet.profileUrl() == null)
+      assert(tweet.profileTimezone() == null)
   }
 }


### PR DESCRIPTION
**GitHub issue(s)**: #194 

# What does this Pull Request do?

Adds the following addition fields to TweetUtils:

  - retweet_count
  - favorite_count
  - in_reply_to_status_id_str
  - in_reply_to_user_id_str
  - in_reply_to_screen_name
  - source
  - user.protected
  - user.profile_image_url
  - user.description
  - user.location
  - user.name
  - user.url
  - user.time_zone


# How should this be tested?

Same as outlined in https://github.com/archivesunleashed/aut/pull/252, but test additional fields.

Tests should take care of it all. But, definitely curious to see how it goes.

# Additional Notes:

Still need to add some addition fields outlined in #194. Entity fields will be interesting since they are all an array.

# Interested parties

@ianmilligan1 @greebie @lintool 
