### PR TITLE
ExtractBoilerpipeText to remove headers as well. #253

### DIFF
--- a/src/main/scala/io/archivesunleashed/matchbox/ExtractBoilerpipeText.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/ExtractBoilerpipeText.scala
@@ -19,10 +19,6 @@ package io.archivesunleashed.matchbox
 import de.l3s.boilerpipe.extractors.DefaultExtractor
 import java.io.IOException
 
-class ExtractedText {
-
-}
-
 /** Extract raw text content from an HTML page, minus "boilerplate" content (using boilerpipe).  */
 object ExtractBoilerpipeText {
   /** Uses boilerpipe to extract raw text content from a page.

--- a/src/main/scala/io/archivesunleashed/matchbox/ExtractBoilerpipeText.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/ExtractBoilerpipeText.scala
@@ -19,6 +19,10 @@ package io.archivesunleashed.matchbox
 import de.l3s.boilerpipe.extractors.DefaultExtractor
 import java.io.IOException
 
+class ExtractedText {
+
+}
+
 /** Extract raw text content from an HTML page, minus "boilerplate" content (using boilerpipe).  */
 object ExtractBoilerpipeText {
   /** Uses boilerpipe to extract raw text content from a page.
@@ -28,12 +32,17 @@ object ExtractBoilerpipeText {
    * @param input an html string possibly containing boilerpipe text
    * @return text with boilerplate removed or Nil if the text is empty.
    */
+
   def apply(input: String): String = {
-    val maybeInput = Option(input)
+    removeBoilerplate(RemoveHttpHeader(input))
+  }
+
+  private def removeBoilerplate(input: String): String = {
+    val maybeInput = Option(DefaultExtractor.INSTANCE
+      .getText(input).replaceAll("[\\r\\n]+", " ").trim())
     maybeInput match {
       case Some(text) =>
-        DefaultExtractor.INSTANCE
-          .getText(input).replaceAll("[\\r\\n]+", " ").trim()
+        text
       case None =>
         ""
     }

--- a/src/test/scala/io/archivesunleashed/matchbox/ExtractBoilerPipeTextTest.scala
+++ b/src/test/scala/io/archivesunleashed/matchbox/ExtractBoilerPipeTextTest.scala
@@ -25,6 +25,9 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ExtractBoilerPipeTextTest extends FunSuite {
+  val header = "HTTP/1.0 200 OK Content-Type: text/html;" +
+   "charset=UTF-8 Expires: Fri, 20 Jul 2018 19:09:28 GMT Date:" +
+   "Fri, 20 Jul 2018 19:09:28 GMT Cache-Control: private,;\r\n\r\n"
   var text = """<p>Text with a boiler plate.<p>
    <footer>Copyright 2017</footer>"""
   var boiler = """Copyright 2017"""
@@ -35,5 +38,9 @@ class ExtractBoilerPipeTextTest extends FunSuite {
     assert(ExtractBoilerpipeText(null) == "")
     // scalastyle:on null
     assert(ExtractBoilerpipeText("All Rights Reserved.") == "")
+  }
+
+  test("Removes Header information") {
+    assert(ExtractBoilerpipeText(header + text) == boiler)
   }
 }


### PR DESCRIPTION


**GitHub issue(s)**:
#253

# What does this Pull Request do?

Alters ExtractBoilerpipeText to remove headers from text output as well.


# How should this be tested?

The test I created + Travis and Codecov should cover it.

# Additional Notes:

I attempted to provide a .keepHeader option, but to do so would require moving the .apply call from the object and that would require documentation changes. This seemed too much to accommodate a fairly marginal use-case.

This option can be provided by returning a class with .keepHeader and .text attributes. I do not think it's too necessary.

# Interested parties

@ianmilligan1

Thanks in advance for your help with the Archives Unleashed Toolkit!
