### PR TITLE
Patch for #246 & #271: Fix exception error when processing corrupted ARC files

### DIFF
--- a/src/main/java/io/archivesunleashed/data/ArcRecordUtils.java
+++ b/src/main/java/io/archivesunleashed/data/ArcRecordUtils.java
@@ -114,8 +114,13 @@ public final class ArcRecordUtils {
               + "URL IP-address Archive-date Content-type Archive-length";
     }
 
-    return copyToByteArray(record, (int) meta.getLength()
-            - versionEtc.length(), true);
+    try {
+      return copyToByteArray(record, (int) meta.getLength()
+              - versionEtc.length(), true);
+    } catch (Exception e) {
+      // Catch exceptions related to any corrupt archive files.
+      return new byte[0];
+    }
   }
 
   /**

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -42,11 +42,11 @@ import scala.util.matching.Regex
 package object archivesunleashed {
   /** Loads records from either WARCs, ARCs or Twitter API data (JSON). */
   object RecordLoader {
-    /** Gets all non-empty archive files
+    /** Gets all non-empty archive files.
       *
       * @param dir the path to the directory containing archive files
       * @param fs filesystem
-      * @return a String consisting of all non-empty archive files path
+      * @return a String consisting of all non-empty archive files path.
       */
     def getFiles(dir: Path, fs: FileSystem): String = {
       val statuses = fs.globStatus(dir)

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -49,8 +49,8 @@ package object archivesunleashed {
       * @return a String consisting of all non-empty archive files path
       */
     def getFiles(dir: Path, fs: FileSystem): String = {
-      val indexFiles = fs.listStatus(dir)
-      val files = indexFiles.filter(f => fs.getContentSummary(f.getPath).getLength > 0).map(f => f.getPath)
+      val statuses = fs.globStatus(dir)
+      val files = statuses.filter(f => fs.getContentSummary(f.getPath).getLength > 0).map(f => f.getPath)
       files.mkString(",")
     }
 


### PR DESCRIPTION
**Patch for #246 & #271: Fix ZipException error when processing corrupted ARC files.**

* * *

**GitHub issue(s)**:

If you are responding to an issue, please mention their numbers below.

* #246 
* #271 

# What does this Pull Request do?

This PR catches exceptions in `getContent()` in `ArcRecordUtils.java` when reading the content of corrupted ARC files, allowing Spark jobs to continue running.

# How should this be tested?

* Build aut on master, as of the latest [commit](https://github.com/archivesunleashed/aut/tree/c95a51d1faabd62fd6700839ed849995bdb7e24d): `mvn clean install`

* Create an output directory with sub-directories:
`mkdir -p path/to/where/ever/you/can/write/output/all-text path/to/where/ever/you/can/write/output/all-domains path/to/where/ever/you/can/write/output/gephi path/to/where/ever/you/can/write/spark-jobs`

* Adapt the script below:
```
import io.archivesunleashed._
import io.archivesunleashed.app._
import io.archivesunleashed.matchbox._
sc.setLogLevel("INFO")

val input = "/tuna1/scratch/aut-issue-271/warcs/*.gz"

val output1 = "/tuna1/scratch/aut-issue-271/derivatives/all-domains"
val output2 = "/tuna1/scratch/aut-issue-271/derivatives/all-text"
val output3 = "/tuna1/scratch/aut-issue-271/derivatives/gephi"

RecordLoader.loadArchives(input, sc).keepValidPages().map(r => ExtractDomain(r.getUrl)).countItems().saveAsTextFile(output1)

RecordLoader.loadArchives(input, sc).keepValidPages().map(r => (r.getCrawlDate, r.getDomain, r.getUrl, RemoveHTML(r.getContentString))).saveAsTextFile(output2)

val links = RecordLoader.loadArchives(input, sc).keepValidPages().map(r => (r.getCrawlDate, ExtractLinks(r.getUrl, r.getContentString))).flatMap(r => r._2.map(f => (r._1, ExtractDomain(f._1).replaceAll("^\\s*www\\.", ""), ExtractDomain(f._2).replaceAll("^\\s*www\\.", "")))).filter(r => r._2 != "" && r._3 != "").countItems().filter(r => r._2 > 5)
WriteGraphML(links, output3)

sys.exit
```

* Run the following command with adapted paths with Apache Spark 2.1.3:
`/home/b25lin/spark-2.1.3-bin-hadoop2.7/bin/spark-shell --master local[10] --driver-memory 30G --conf spark.network.timeout=100000000 --conf spark.executor.heartbeatInterval=6000s --conf spark.driver.maxResultSize=10G --jars "/tuna1/scratch/borislin/aut/target/aut-0.16.1-SNAPSHOT-fatjar.jar" -i /tuna1/scratch/aut-issue-271/spark_jobs/499.scala | tee /tuna1/scratch/aut-issue-271/spark_jobs/499.scala.log`

# Current results

`/tuna1/scratch/aut-issue-271/spark_jobs/499.scala.log`
`/tuna1/scratch/aut-issue-271/derivatives`

# Interested parties

@lintool @ianmilligan1 @ruebot 
