### PR TITLE
Clean-up pom.xml to remove plugin warnings; resolves #273.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
     <project-info-reports.plugin.version>2.7</project-info-reports.plugin.version>
     <doxia-markdown.plugin.version>1.7</doxia-markdown.plugin.version>
     <failsafe.plugin.version>2.18.1</failsafe.plugin.version>
-    <javadoc.plugin.version>2.10.3</javadoc.plugin.version>
     <jxr.plugin.version>2.5</jxr.plugin.version>
     <surefire.plugin.version>2.18.1</surefire.plugin.version>
     <jacoco.plugin.version>0.7.5.201505241946</jacoco.plugin.version>
@@ -737,6 +736,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-javadoc-plugin</artifactId>
+              <version>${javadoc.plugin.version}</version>
             </plugin>
             <plugin>
               <artifactId>maven-gpg-plugin</artifactId>
@@ -760,6 +760,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
+            <version>${gpg.plugin.version}</version>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
**GitHub issue(s)**: #273 

# What does this Pull Request do?

- Clean-up pom.xml to remove plugin warnings; resolves #273. 
- The removed `javadoc.plugin.version`  is because there were actually two of them in that section with two different versions. 🤯

# How should this be tested?

* TravisCI should pass.
* Local build should not show previous warnings (as shown in #273) during this build or
  - `mvn release:clean`
  - `mvn release:prepare -DreleaseVersion=0.17.1 -DdevelopmentVersion=0.17.2-SNAPSHOT -DautoVersionSubmodules=true -DpushChanges=false`

# Additional Notes:

Not sure how to have others test this since you might need signing keys setup, and a `~/.m2/settings.xml` setup as described [here](https://github.com/archivesunleashed/aut/wiki/Release-Process)