### PR TITLE
Patch for #277: Fix bug and unit test for ExtractDomain

### DIFF
--- a/src/main/scala/io/archivesunleashed/matchbox/ExtractDomain.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/ExtractDomain.scala
@@ -27,16 +27,16 @@ object ExtractDomain {
    * @return domain host, source or null if url is null.
    */
   def apply(url: String, source: String = ""): String = {
-    val maybeSource: Option[URL] = checkUrl(source)
     val maybeHost: Option[URL] = checkUrl(url)
-    maybeSource match {
-      case Some(source) =>
-        source.getHost
+    val maybeSource: Option[URL] = checkUrl(source)
+    maybeHost match {
+      case Some(host) =>
+        host.getHost
 
       case None =>
-        maybeHost match {
-          case Some(host) =>
-            host.getHost
+        maybeSource match {
+          case Some(source) =>
+            source.getHost
           case None =>
             ""
       }

--- a/src/test/scala/io/archivesunleashed/matchbox/ExtractDomainTest.scala
+++ b/src/test/scala/io/archivesunleashed/matchbox/ExtractDomainTest.scala
@@ -34,7 +34,8 @@ class ExtractDomainTest extends FunSuite {
 
   private val data2 = Seq.newBuilder.+=(
     (index, "http://www.umiacs.umd.edu/~jimmylin/", umiacs),
-    (index, "lintool/", "")).result()
+    ("https://github.com/lintool", "http://www.umiacs.umd.edu/~jimmylin/", "github.com"),
+    (index, "https://github.com/lintool", "github.com")).result()
 
   test("simple") {
     data1.foreach {


### PR DESCRIPTION
**This PR fixes the wrong order of `url` and `source` checking in `ExtractDomain`.**

* * *

**GitHub issue(s)**:

* #277

# What does this Pull Request do?

This PR improves unit test for `ExtractDomain` to catch a bug where `ExtractDomain` mistakenly checks `source` first then `url`, and also fixes the bug by reversing the checking order of `source` and `url`.

# How should this be tested?

* Follow steps in #277 to reproduce the error and build will fail
* `git fetch --all`
* `git checkout fix-extractdomain`
* `mvn clean package`
* build should now pass

# Interested parties

@lintool @greebie @ruebot 
