### PR TITLE
Update Apache Tika - security vulnerabilities; resolves #131.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -573,12 +573,12 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
-      <version>1.12</version>
+      <version>1.19.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
-      <version>1.12</version>
+      <version>1.19.1</version>
     </dependency>
     <dependency>
       <groupId>org.rogach</groupId>


### PR DESCRIPTION
**GitHub issue(s)**: #131 

# What does this Pull Request do?

Update Apache Tika to 1.19.1 for the following security vulnerabilities:

- CVE-2018-1338
- CVE-2018-11762
- CVE-2018-11761
- CVE-2016-6809
- CVE-2018-1339
- CVE-2018-11796
- CVE-2016-4434
- CVE-2018-1335

# How should this be tested?

TravisCI _should_ take care of it. If there is any language analysis scripts laying around, we should double check those.

# Additional Notes:

This creates a build warning:

```
[WARNING] /home/nruest/git/aut/src/main/scala/io/archivesunleashed/matchbox/DetectLanguage.scala:33: warning: class LanguageIdentifier in package language is deprecated: see corresponding Javadoc for more information.
[INFO]       new LanguageIdentifier(input).getLanguage
[INFO]           ^
[WARNING] one warning found
```


Follow-on ticket #286 