### PR TITLE
Change Id generation for graphs from using hashes for urls to using .zipWithUniqueIds()

### DIFF
--- a/src/main/scala/io/archivesunleashed/app/WriteGEXF.scala
+++ b/src/main/scala/io/archivesunleashed/app/WriteGEXF.scala
@@ -117,7 +117,7 @@ object WriteGEXF {
       "<edge source=\"" +
       sid + "\" target=\"" +
       did + "\" weight=\"" + weight +
-      "\" type=\"directed\"\n" +
+      "\" type=\"directed\">\n" +
       "<attvalues>\n" +
       "<attvalue for=\"0\" value=\"" + date + endAttribute +
       "</attvalues>\n" +

--- a/src/main/scala/io/archivesunleashed/app/WriteGEXF.scala
+++ b/src/main/scala/io/archivesunleashed/app/WriteGEXF.scala
@@ -51,6 +51,55 @@ object WriteGEXF {
       makeFile (ds, gexfPath)
     }
   }
+  /** Produces a zipped RDD with ids and labels from an network-based RDD, rdd.
+   * @param rdd a RDD of elements in format ((datestring, source, target), count)
+   * @return an RDD containing (Label, UniqueId)
+   */
+  def nodesWithIds (rdd: RDD[((String, String, String), Int)]): RDD[(String, Long)] = {
+    rdd.map(r => r._1._2.escapeInvalidXML())
+      .union(rdd.map(r => r._1._3.escapeInvalidXML()))
+      .distinct
+      .zipWithUniqueId()
+  }
+
+  /** Produces the (label, id) combination from a nodeslist of an RDD that has the
+   * same label as lookup.
+   * @param rdd an RDD of elements in format ((datestring, source, target), count)
+   * @param lookup the label to lookup.
+   * @return an Option containing Some(Label, UniqueId) or None
+   */
+  def nodeLookup (rdd: RDD[(String, Long)], lookup: String): Option[(String, Long)] = {
+    rdd.filter(r => r._1 contains lookup)
+      .collect
+      .lift(0)
+  }
+
+  /** Produces the id from Nodelookup
+   * @param id an Option containing the lookup.
+   * @return a long representing the id or -1 if no id exists from the lookup.
+   */
+  def nodeIdFromLabel (id: Option[(String, Long)]): Long = {
+    id match {
+      case Some(x) => x._2
+      case None => -1
+    }
+  }
+
+  /**  Produces uniqueIds for edge lists from a flatMapped rdd, using nodesWithIds
+   * @param rdd an RDD of elements in format ((datestring, source, target), count)
+   * @return an RDD in format (date, sourceid, destinationid, count)
+   */
+  def edgeNodes (rdd: RDD[((String, String, String), Int)]) : RDD[(String, Long, Long, Int)] = {
+    val nodes = nodesWithIds(rdd)
+    rdd.map(r => (r._1._2, (r._1._3, r._1._1, r._2)))
+       .rightOuterJoin(nodes)
+       .filter(r => r._2._1 != None)
+       .map( { case (source, (Some((destination, date, weight)), sid))
+         => (destination, (sid, source, date, weight)) })
+      .leftOuterJoin(nodes).filter( r => r._2._1 != None)
+      .map ({ case (dest, ((sid, source, date, weight), Some(did)))
+        => (date, sid, did, weight)})
+  }
 
   /** Produces the GEXF output from a RDD of tuples and outputs it to gexfPath.
    *
@@ -63,19 +112,16 @@ object WriteGEXF {
     val endAttribute = "\" />\n"
     val nodeStart = "<node id=\""
     val labelStart = "\" label=\""
-    val edges = rdd.map(r => "<edge source=\"" + r._1._2.computeHash() + "\" target=\"" +
-      r._1._3.computeHash() + "\" weight=\"" + r._2 +
-      "\" type=\"directed\">\n" +
+    val nodes = nodesWithIds(rdd)
+    val edges = edgeNodes(rdd).map({ case (date, sid, did, weight) =>
+      "<edge source=\"" +
+      sid + "\" target=\"" +
+      did + "\" weight=\"" + weight +
+      "\" type=\"directed\"\n" +
       "<attvalues>\n" +
-      "<attvalue for=\"0\" value=\"" + r._1._1 + endAttribute +
+      "<attvalue for=\"0\" value=\"" + date + endAttribute +
       "</attvalues>\n" +
-      "</edge>\n").collect
-    val nodes = rdd.flatMap(r => List(nodeStart +
-      r._1._2.computeHash() + labelStart +
-      r._1._2.escapeInvalidXML() + endAttribute,
-      nodeStart +
-      r._1._3.computeHash() + labelStart +
-      r._1._3.escapeInvalidXML() + endAttribute)).distinct.collect
+      "</edge>\n"}).collect
     outFile.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
       "<gexf xmlns=\"http://www.gexf.net/1.3draft\"\n" +
       "  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
@@ -87,7 +133,11 @@ object WriteGEXF {
       "  <attribute id=\"0\" title=\"crawlDate\" type=\"string\" />\n" +
       "</attributes>\n" +
       "<nodes>\n")
-    nodes.foreach(r => outFile.write(r))
+    nodes.map(r => nodeStart +
+      r._2 + labelStart +
+      r._1 + endAttribute)
+      .collect
+      .foreach(r => outFile.write(r))
     outFile.write("</nodes>\n<edges>\n")
     edges.foreach(r => outFile.write(r))
     outFile.write("</edges>\n</graph>\n</gexf>")

--- a/src/main/scala/io/archivesunleashed/app/WriteGraph.scala
+++ b/src/main/scala/io/archivesunleashed/app/WriteGraph.scala
@@ -31,7 +31,7 @@ object WriteGraph {
   val nodeStart = "<node id=\""
   val edgeStart = "<edge source=\""
   val targetChunk = "\" target=\""
-  val directedChunk = " type=\"directed\">\n"
+  val directedChunk = "\" type=\"directed\">\n"
   val endAttribute = "\" />\n"
   val labelStart = "\" label=\""
   val xmlHeader = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
@@ -139,7 +139,7 @@ object WriteGraph {
         edgeStart  +
         sid + targetChunk +
         did + "\" weight=\"" + weight +
-        "\" type=\"directed\">\n" +
+        directedChunk +
         "<attvalues>\n" +
         "<attvalue for=\"0\" value=\"" + date + endAttribute +
         "</attvalues>\n" +

--- a/src/main/scala/io/archivesunleashed/app/WriteGraph.scala
+++ b/src/main/scala/io/archivesunleashed/app/WriteGraph.scala
@@ -59,7 +59,7 @@ object WriteGraph {
   }
 
   def apply(ds: Array[Row], gexfPath: String): Boolean = {
-    if (!gexfPath.isEmpty())  { asGexf(ds, gexfPath) } else { false }
+    if (!gexfPath.isEmpty())  { asGexf (ds, gexfPath) } else { false }
   }
 
   /** Produces a zipped RDD with ids and labels from an network-based RDD, rdd.
@@ -120,7 +120,7 @@ object WriteGraph {
    * @return true on success.
    */
   def asGexf (rdd: RDD[((String, String, String), Int)], gexfPath: String): Boolean = {
-    if (!gexfPath.isEmpty()) {
+    if (gexfPath.isEmpty()) {
       false
     } else {
       val nodes = nodesWithIds(rdd)

--- a/src/main/scala/io/archivesunleashed/app/WriteGraph.scala
+++ b/src/main/scala/io/archivesunleashed/app/WriteGraph.scala
@@ -55,20 +55,11 @@ object WriteGraph {
    * @return Unit().
    */
   def apply(rdd: RDD[((String, String, String), Int)], gexfPath: String): Boolean = {
-    if (gexfPath.isEmpty()) {
-      false
-    } else
-    {
-      asGexf (rdd, gexfPath)
-    }
+    if (!gexfPath.isEmpty()) { asGexf (rdd, gexfPath) } else { false }
   }
 
   def apply(ds: Array[Row], gexfPath: String): Boolean = {
-    if (gexfPath.isEmpty())  {
-      false
-    } else {
-      asGexf (ds, gexfPath)
-    }
+    if (!gexfPath.isEmpty())  { asGexf(ds, gexfPath) } else { false }
   }
 
   /** Produces a zipped RDD with ids and labels from an network-based RDD, rdd.
@@ -129,10 +120,9 @@ object WriteGraph {
    * @return true on success.
    */
   def asGexf (rdd: RDD[((String, String, String), Int)], gexfPath: String): Boolean = {
-    if (gexfPath.isEmpty()) {
+    if (!gexfPath.isEmpty()) {
       false
-    } else
-    {
+    } else {
       val nodes = nodesWithIds(rdd)
       val outFile = Files.newBufferedWriter(Paths.get(gexfPath), StandardCharsets.UTF_8)
       val edges = edgeNodes(rdd).map({ case (date, sid, did, weight) =>
@@ -171,11 +161,10 @@ object WriteGraph {
   def asGexf (data: Array[Row], gexfPath: String): Boolean = {
     if (gexfPath.isEmpty()) {
       false
-    } else
-    {
+    } else {
       val outFile = Files.newBufferedWriter(Paths.get(gexfPath), StandardCharsets.UTF_8)
       val vertices = scala.collection.mutable.Set[String]()
-      data foreach { d =>
+      data.foreach { d =>
         vertices.add(d.get(1).asInstanceOf[String])
         vertices.add(d.get(2).asInstanceOf[String])
       }
@@ -185,13 +174,13 @@ object WriteGraph {
         "  <attribute id=\"0\" title=\"crawlDate\" type=\"string\" />\n" +
         "</attributes>\n" +
         "<nodes>\n")
-      vertices foreach { v =>
+      vertices.foreach { v =>
         outFile.write(nodeStart +
           v.computeHash() + "\" label=\"" +
           v.escapeInvalidXML() + endAttribute)
       }
       outFile.write("</nodes>\n<edges>\n")
-      data foreach { e =>
+      data.foreach { e =>
         outFile.write(edgeStart + e.get(1).asInstanceOf[String].computeHash() + targetChunk +
           e.get(2).asInstanceOf[String].computeHash() + "\" weight=\"" + e.get(3) +
           "\" type=\"directed\">\n" +
@@ -209,8 +198,7 @@ object WriteGraph {
   def asGraphml (rdd: RDD[((String, String, String), Int)], graphmlPath: String): Boolean = {
     if (graphmlPath.isEmpty()) {
       false
-    } else
-    {
+    } else {
       val nodes = nodesWithIds(rdd)
       val outFile = Files.newBufferedWriter(Paths.get(graphmlPath), StandardCharsets.UTF_8)
       val edges = edgeNodes(rdd).map({ case (date, sid, did, weight) =>

--- a/src/main/scala/io/archivesunleashed/app/WriteGraph.scala
+++ b/src/main/scala/io/archivesunleashed/app/WriteGraph.scala
@@ -1,0 +1,239 @@
+/*
+ * Archives Unleashed Toolkit (AUT):
+ * An open-source platform for analyzing web archives.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.archivesunleashed.app
+// scalastyle:off underscore.import
+import io.archivesunleashed.matchbox._
+// scalastyle:on underscore.import
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+
+/**
+  * UDF for exporting an RDD representing a collection of links to a GEXF file.
+  */
+object WriteGraph {
+
+  val nodeStart = "<node id=\""
+  val edgeStart = "<edge source=\""
+  val targetChunk = "\" target=\""
+  val directedChunk = " type=\"directed\">\n"
+  val endAttribute = "\" />\n"
+  val labelStart = "\" label=\""
+  val xmlHeader = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+  val edgeEnd = "</edge>\n"
+  val gexfHeader = xmlHeader +
+    "<gexf xmlns=\"http://www.gexf.net/1.3draft\"\n" +
+    "  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+    "  xsi:schemaLocation=\"http://www.gexf.net/1.3draft\n" +
+    "                       http://www.gexf.net/1.3draft/gexf.xsd\"\n" +
+    "  version=\"1.3\">\n"
+  val graphmlHeader = xmlHeader +
+    "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"\n" +
+    "  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+    "  xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns\n" +
+    "  http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\"\n>"
+
+  /** Writes graph nodes and edges to file.
+   *
+   * @param rdd RDD of elements in format ((datestring, source, target), count)
+   * @param gexfPath output file
+   * @return Unit().
+   */
+  def apply(rdd: RDD[((String, String, String), Int)], gexfPath: String): Boolean = {
+    if (gexfPath.isEmpty()) {
+      false
+    } else
+    {
+      asGexf (rdd, gexfPath)
+    }
+  }
+
+  def apply(ds: Array[Row], gexfPath: String): Boolean = {
+    if (gexfPath.isEmpty())  {
+      false
+    } else {
+      asGexf (ds, gexfPath)
+    }
+  }
+
+  /** Produces a zipped RDD with ids and labels from an network-based RDD, rdd.
+   * @param rdd a RDD of elements in format ((datestring, source, target), count)
+   * @return an RDD containing (Label, UniqueId)
+   */
+  def nodesWithIds (rdd: RDD[((String, String, String), Int)]): RDD[(String, Long)] = {
+    rdd.map(r => r._1._2.escapeInvalidXML())
+      .union(rdd.map(r => r._1._3.escapeInvalidXML()))
+      .distinct
+      .zipWithUniqueId()
+  }
+
+  /** Produces the (label, id) combination from a nodeslist of an RDD that has the
+   * same label as lookup.
+   * @param rdd an RDD of elements in format ((datestring, source, target), count)
+   * @param lookup the label to lookup.
+   * @return an Option containing Some(Label, UniqueId) or None
+   */
+  def nodeLookup (rdd: RDD[(String, Long)], lookup: String): Option[(String, Long)] = {
+    rdd.filter(r => r._1 contains lookup)
+      .collect
+      .lift(0)
+  }
+
+  /** Produces the id from Nodelookup
+   * @param id an Option containing the lookup.
+   * @return a long representing the id or -1 if no id exists from the lookup.
+   */
+  def nodeIdFromLabel (id: Option[(String, Long)]): Long = {
+    id match {
+      case Some(x) => x._2
+      case None => -1
+    }
+  }
+
+  /**  Produces uniqueIds for edge lists from a flatMapped rdd, using nodesWithIds
+   * @param rdd an RDD of elements in format ((datestring, source, target), count)
+   * @return an RDD in format (date, sourceid, destinationid, count)
+   */
+  def edgeNodes (rdd: RDD[((String, String, String), Int)]) : RDD[(String, Long, Long, Int)] = {
+    val nodes = nodesWithIds(rdd)
+    rdd.map(r => (r._1._2, (r._1._3, r._1._1, r._2)))
+       .rightOuterJoin(nodes) // create ids for source urls from nodes.
+       .filter(r => r._2._1 != None)
+       .map( { case (source, (Some((destination, date, weight)), sid))
+         => (destination, (sid, source, date, weight)) })
+      .leftOuterJoin(nodes) // create ids for destination urls from nodes.
+      .filter( r => r._2._1 != None)
+      .map ({ case (dest, ((sid, source, date, weight), Some(did)))
+        => (date, sid, did, weight)})
+  }
+
+  /** Produces the GEXF output from a RDD of tuples and outputs it to gexfPath.
+   *
+   * @param rdd a RDD of elements in format ((datestring, source, target), count)
+   * @param gexfPath output file
+   * @return true on success.
+   */
+  def asGexf (rdd: RDD[((String, String, String), Int)], gexfPath: String): Boolean = {
+    if (gexfPath.isEmpty()) {
+      false
+    } else
+    {
+      val nodes = nodesWithIds(rdd)
+      val outFile = Files.newBufferedWriter(Paths.get(gexfPath), StandardCharsets.UTF_8)
+      val edges = edgeNodes(rdd).map({ case (date, sid, did, weight) =>
+        edgeStart  +
+        sid + targetChunk +
+        did + "\" weight=\"" + weight +
+        "\" type=\"directed\">\n" +
+        "<attvalues>\n" +
+        "<attvalue for=\"0\" value=\"" + date + endAttribute +
+        "</attvalues>\n" +
+        edgeEnd})
+      outFile.write(gexfHeader +
+        "<graph mode=\"static\" defaultedgetype=\"directed\">\n" +
+        "<attributes class=\"edge\">\n" +
+        "  <attribute id=\"0\" title=\"crawlDate\" type=\"string\" />\n" +
+        "</attributes>\n" +
+        "<nodes>\n")
+      nodes.map(r => nodeStart +
+        r._2 + labelStart +
+        r._1 + endAttribute).collect
+        .foreach(r => outFile.write(r))
+      outFile.write("</nodes>\n<edges>\n")
+      edges.collect.foreach(r => outFile.write(r))
+      outFile.write("</edges>\n</graph>\n</gexf>")
+      outFile.close()
+      true
+    }
+  }
+
+  /** Produces the GEXF output from an Array[Row] and outputs it to gexfPath.
+    *
+    * @param data a Dataset[Row] of elements in format (datestring, source, target, count)
+    * @param gexfPath output file
+    * @return true on success.
+    */
+  def asGexf (data: Array[Row], gexfPath: String): Boolean = {
+    if (gexfPath.isEmpty()) {
+      false
+    } else
+    {
+      val outFile = Files.newBufferedWriter(Paths.get(gexfPath), StandardCharsets.UTF_8)
+      val vertices = scala.collection.mutable.Set[String]()
+      data foreach { d =>
+        vertices.add(d.get(1).asInstanceOf[String])
+        vertices.add(d.get(2).asInstanceOf[String])
+      }
+      outFile.write(gexfHeader +
+        "<graph mode=\"static\" defaultedgetype=\"directed\">\n" +
+        "<attributes class=\"edge\">\n" +
+        "  <attribute id=\"0\" title=\"crawlDate\" type=\"string\" />\n" +
+        "</attributes>\n" +
+        "<nodes>\n")
+      vertices foreach { v =>
+        outFile.write(nodeStart +
+          v.computeHash() + "\" label=\"" +
+          v.escapeInvalidXML() + endAttribute)
+      }
+      outFile.write("</nodes>\n<edges>\n")
+      data foreach { e =>
+        outFile.write(edgeStart + e.get(1).asInstanceOf[String].computeHash() + targetChunk +
+          e.get(2).asInstanceOf[String].computeHash() + "\" weight=\"" + e.get(3) +
+          "\" type=\"directed\">\n" +
+          "<attvalues>\n" +
+          "<attvalue for=\"0\" value=\"" + e.get(0) + endAttribute +
+          "</attvalues>\n" +
+          edgeEnd)
+      }
+      outFile.write("</edges>\n</graph>\n</gexf>")
+      outFile.close()
+      true
+    }
+  }
+
+  def asGraphml (rdd: RDD[((String, String, String), Int)], graphmlPath: String): Boolean = {
+    if (graphmlPath.isEmpty()) {
+      false
+    } else
+    {
+      val nodes = nodesWithIds(rdd)
+      val outFile = Files.newBufferedWriter(Paths.get(graphmlPath), StandardCharsets.UTF_8)
+      val edges = edgeNodes(rdd).map({ case (date, sid, did, weight) =>
+        edgeStart +
+        sid + targetChunk +
+        did + directedChunk +
+        "<data key=\"weight\">" + weight + "</data>\n" +
+        "<data key=\"crawlDate\">" + date + "</data>\n" +
+        edgeEnd})
+      outFile.write(graphmlHeader +
+        "<key id=\"label\" for=\"node\" attr.name=\"label\" attr.type=\"string\" />\n" +
+        "<key id=\"weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">\n" +
+        "<default>0.0</default>\n" +
+        "</key>\n" +
+        "<key id=\"crawlDate\" for=\"edge\" attr.name=\"crawlDate\" attr.type=\"string\" />\n" +
+        "<graph mode=\"static\" edgedefault=\"directed\">\n")
+      nodes.map(r => nodeStart + r._2 + "\">\n" +
+        "<data key=\"label\">" + r._1 + "\"</data>\n</node>\n").collect
+         .foreach(r => outFile.write(r))
+      edges.collect.foreach(r => outFile.write(r))
+      outFile.write("</graph>\n</graphml>")
+      outFile.close()
+      true
+    }
+  }
+}

--- a/src/main/scala/io/archivesunleashed/app/WriteGraph.scala
+++ b/src/main/scala/io/archivesunleashed/app/WriteGraph.scala
@@ -102,7 +102,7 @@ object WriteGraph {
    */
   def edgeNodes (rdd: RDD[((String, String, String), Int)]) : RDD[(String, Long, Long, Int)] = {
     val nodes = nodesWithIds(rdd)
-    rdd.map(r => (r._1._2, (r._1._3, r._1._1, r._2)))
+    rdd.map(r => (r._1._2.escapeInvalidXML(), (r._1._3.escapeInvalidXML(), r._1._1, r._2)))
        .rightOuterJoin(nodes) // create ids for source urls from nodes.
        .filter(r => r._2._1 != None)
        .map( { case (source, (Some((destination, date, weight)), sid))
@@ -216,7 +216,7 @@ object WriteGraph {
         "<key id=\"crawlDate\" for=\"edge\" attr.name=\"crawlDate\" attr.type=\"string\" />\n" +
         "<graph mode=\"static\" edgedefault=\"directed\">\n")
       nodes.map(r => nodeStart + r._2 + "\">\n" +
-        "<data key=\"label\">" + r._1 + "\"</data>\n</node>\n").collect
+        "<data key=\"label\">" + r._1 + "</data>\n</node>\n").collect
          .foreach(r => outFile.write(r))
       edges.collect.foreach(r => outFile.write(r))
       outFile.write("</graph>\n</graphml>")

--- a/src/test/scala/io/archivesunleashed/app/WriteGEXFTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/WriteGEXFTest.scala
@@ -38,6 +38,9 @@ class WriteGEXFTest extends FunSuite with BeforeAndAfter{
   private val networkDf = Seq(("Date1", "Source1", "Destination1", 3),
                          ("Date2", "Source2", "Destination2", 4),
                          ("Date3", "Source3", "Destination3", 100))
+  private val networkWithDuplication = Seq((("Date1", "Source1", "Destination1"), 3),
+                         (("Date2", "Source2", "Source2"), 4),
+                         (("Date3", "Source3", "Destination3"), 100))
   private val testFile = "temporaryTestFile.txt"
 
   before {
@@ -55,7 +58,7 @@ class WriteGEXFTest extends FunSuite with BeforeAndAfter{
     assert(Files.exists(Paths.get(testFile)))
     val lines = Source.fromFile(testFile).getLines.toList
     assert(lines(testLines._1) == """<?xml version="1.0" encoding="UTF-8"?>""")
-    assert(lines(testLines._2) == """<node id="f61def1ec71cd27401b8c821f04b7c27" label="Destination1" />""")
+    assert(lines(testLines._2) == """<node id="3" label="Destination1" />""")
     assert(lines(testLines._3) == """</attvalues>""")
     assert(lines(testLines._4) == """</edges>""")
   }
@@ -82,6 +85,39 @@ class WriteGEXFTest extends FunSuite with BeforeAndAfter{
     val gexf = WriteGEXF(networkrdd, testFile)
     assert(gexf)
     assert(!WriteGEXF(networkrdd, ""))
+  }
+
+  test ("Nodes zip with ids") {
+    val networkrdd = sc.parallelize(networkWithDuplication)
+    val expected = WriteGEXF.nodesWithIds(networkrdd).collect
+    assert (expected.length == 5)
+    assert (expected(0) == ("Source3", 0))
+  }
+
+  test ("Nodelookup returns a option") {
+    val networkrdd = sc.parallelize(network)
+    val nodes = WriteGEXF.nodesWithIds(networkrdd)
+    val lookup = "Source1"
+    val badlookup = "NOTHERE"
+    assert (WriteGEXF.nodeLookup(nodes, badlookup) == None)
+    assert (WriteGEXF.nodeLookup(nodes, lookup) == Some(("Source1", 6)))
+  }
+
+  test ("Gets the id from a lookup") {
+    val nodes = WriteGEXF.nodesWithIds(sc.parallelize(network))
+    val empty = -1
+    val expected = 6
+    val lookup = WriteGEXF.nodeLookup(nodes, "Source1")
+    val badlookup = WriteGEXF.nodeLookup(nodes, "NOTTHERE")
+    assert (WriteGEXF.nodeIdFromLabel(lookup) == expected)
+    assert (WriteGEXF.nodeIdFromLabel(badlookup) == -1)
+  }
+
+  test ("Edge ids are captured from lookup") {
+    val edges = WriteGEXF.edgeNodes(sc.parallelize(network))
+    assert(edges.collect.deep == Array(("Date1", 6, 3, 3),
+      ("Date2", 7, 4, 4),
+      ("Date3", 0, 5, 100)).deep)
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
@@ -1,0 +1,134 @@
+/*
+ * Archives Unleashed Toolkit (AUT):
+ * An open-source platform for analyzing web archives.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.archivesunleashed.app
+
+import java.io.File
+import java.nio.file.{Files, Paths}
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.apache.spark.sql.Row
+
+import scala.io.Source
+
+@RunWith(classOf[JUnitRunner])
+class WriteGraphTest extends FunSuite with BeforeAndAfter{
+  private var sc: SparkContext = _
+  private val master = "local[4]"
+  private val appName = "example-spark"
+  private val network = Seq((("Date1", "Source1", "Destination1"), 3),
+                         (("Date2", "Source2", "Destination2"), 4),
+                         (("Date3", "Source3", "Destination3"), 100))
+  private val networkDf = Seq(("Date1", "Source1", "Destination1", 3),
+                         ("Date2", "Source2", "Destination2", 4),
+                         ("Date3", "Source3", "Destination3", 100))
+  private val networkWithDuplication = Seq((("Date1", "Source1", "Destination1"), 3),
+                         (("Date2", "Source2", "Source2"), 4),
+                         (("Date3", "Source3", "Destination3"), 100))
+  private val testFile = "temporaryTestFile.txt"
+
+  before {
+    val conf = new SparkConf()
+      .setMaster(master)
+      .setAppName(appName)
+      conf.set("spark.driver.allowMultipleContexts", "true");
+      sc = new SparkContext(conf)
+    }
+
+  test("creates the file") {
+    val testLines = (0, 12, 22, 34)
+    val networkrdd = sc.parallelize(network)
+    WriteGraph.asGexf(networkrdd, testFile)
+    assert(Files.exists(Paths.get(testFile)))
+    val lines = Source.fromFile(testFile).getLines.toList
+    assert(lines(testLines._1) == """<?xml version="1.0" encoding="UTF-8"?>""")
+    assert(lines(testLines._2) == """<node id="3" label="Destination1" />""")
+    assert(lines(testLines._3) == """</attvalues>""")
+    assert(lines(testLines._4) == """</edges>""")
+  }
+
+  test("creates the file from Array[Row]") {
+    val testLines = (0, 12, 22, 34)
+    if (Files.exists(Paths.get(testFile))) {
+      new File(testFile).delete()
+    }
+    val networkarray = Array(Row.fromTuple(networkDf(0)),
+      Row.fromTuple(networkDf(1)), Row.fromTuple(networkDf(2)))
+    val ret = WriteGraph.asGexf(networkarray, testFile)
+    assert(ret)
+    val lines = Source.fromFile(testFile).getLines.toList
+    assert(lines(testLines._1) == """<?xml version="1.0" encoding="UTF-8"?>""")
+    assert(lines(testLines._2) == """<node id="8d3ab53ec817a1e5bf9ffd6e749b3983" label="Destination2" />""")
+    assert(lines(testLines._3) == """</attvalues>""")
+    assert(lines(testLines._4) == """</edges>""")
+    assert(!WriteGraph.asGexf(networkarray ,""))
+  }
+
+  test ("returns a Bool depending on pass or failure") {
+    val networkrdd = sc.parallelize(network)
+    val gexf = WriteGraph.asGexf(networkrdd, testFile)
+    assert(gexf)
+    assert(!WriteGraph.asGexf(networkrdd, ""))
+  }
+
+  test ("Nodes zip with ids") {
+    val networkrdd = sc.parallelize(networkWithDuplication)
+    val nodeIds = WriteGraph.nodesWithIds(networkrdd).collect
+    val expected = ("Source3", 0)
+    val expectedLength = 5
+    assert (nodeIds.length == expectedLength)
+    assert (nodeIds(0) == expected)
+  }
+
+  test ("Nodelookup returns a option") {
+    val networkrdd = sc.parallelize(network)
+    val nodes = WriteGraph.nodesWithIds(networkrdd)
+    val lookup = "Source1"
+    val badlookup = "NOTHERE"
+    assert (WriteGraph.nodeLookup(nodes, badlookup) == None)
+    assert (WriteGraph.nodeLookup(nodes, lookup) == Some((lookup, 6)))
+  }
+
+  test ("Gets the id from a lookup") {
+    val nodes = WriteGraph.nodesWithIds(sc.parallelize(network))
+    val empty = -1
+    val expected = 6
+    val lookup = WriteGraph.nodeLookup(nodes, "Source1")
+    val badlookup = WriteGraph.nodeLookup(nodes, "NOTTHERE")
+    assert (WriteGraph.nodeIdFromLabel(lookup) == expected)
+    assert (WriteGraph.nodeIdFromLabel(badlookup) == empty)
+  }
+
+  test ("Edge ids are captured from lookup") {
+    val edges = WriteGraph.edgeNodes(sc.parallelize(network))
+    val expected = Array(("Date1", 6, 3, 3),
+      ("Date2", 7, 4, 4),
+      ("Date3", 0, 5, 100)).deep
+    assert(edges.collect.deep == expected)
+  }
+
+  after {
+    if (sc != null) {
+      sc.stop()
+    }
+    if (Files.exists(Paths.get(testFile))) {
+      new File(testFile).delete()
+    }
+  }
+}

--- a/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
@@ -45,6 +45,7 @@ class WriteGraphTest extends FunSuite with BeforeAndAfter{
                          (("Date2", "Source2", "Source2"), 4),
                          (("Date3", "Source3", "Destination3"), 100))
   private val testFile = "temporaryTestFile.txt"
+  private val testFile2 = "temporaryTestFile2.txt"
 
   before {
     val conf = new SparkConf()
@@ -137,7 +138,8 @@ class WriteGraphTest extends FunSuite with BeforeAndAfter{
     assert(lines(testLines._3) == """<data key="weight">3</data>""")
     assert(lines(testLines._4) == """<edge source="0" target="5" type="directed">""")
   }
-  test ("Graphml and gexf work with unescaped xml date") {
+
+  test ("Graphml works with unescaped xml data") {
     val testLines = (0, 12, 30, 37)
     val networkrdd = sc.parallelize(unescapedNetwork)
     WriteGraph.asGraphml(networkrdd, testFile)
@@ -149,12 +151,25 @@ class WriteGraphTest extends FunSuite with BeforeAndAfter{
     assert(lines(testLines._4) == """<edge source="7" target="4" type="directed">""")
   }
 
+  test( "Gexf works with unescaped xml data") {
+    val testLines = (0, 12, 29, 31)
+    val networkrdd = sc.parallelize(unescapedNetwork)
+    WriteGraph(networkrdd, testFile2)
+    assert(Files.exists(Paths.get(testFile2)))
+    val lines = Source.fromFile(testFile2).getLines.toList
+    assert(lines(testLines._1) == """<?xml version="1.0" encoding="UTF-8"?>""")
+    assert(lines(testLines._2) == """<node id="3" label="Source&lt;3" />""")
+    assert(lines(testLines._3) == """<edge source="7" target="4" weight="4" type="directed">""")
+    assert(lines(testLines._4) == """<attvalue for="0" value="Date2" />""")
+  }
+
   after {
     if (sc != null) {
       sc.stop()
     }
-    if (Files.exists(Paths.get(testFile))) {
+    if (Files.exists(Paths.get(testFile)) || Files.exists(Paths.get(testFile2))) {
       new File(testFile).delete()
+      new File(testFile2).delete()
     }
   }
 }

--- a/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
@@ -132,7 +132,7 @@ class WriteGraphTest extends FunSuite with BeforeAndAfter{
     assert(lines(testLines._1) == """<?xml version="1.0" encoding="UTF-8"?>""")
     assert(lines(testLines._2) == """<data key="label">Source3"</data>""")
     assert(lines(testLines._3) == """<data key="weight">3</data>""")
-    assert(lines(testLines._4) == """<edge source="0" target="5 type="directed">""")
+    assert(lines(testLines._4) == """<edge source="0" target="5" type="directed">""")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
@@ -49,7 +49,7 @@ class WriteGraphTest extends FunSuite with BeforeAndAfter{
       .setAppName(appName)
       conf.set("spark.driver.allowMultipleContexts", "true");
       sc = new SparkContext(conf)
-    }
+  }
 
   test("creates the file") {
     val testLines = (0, 12, 22, 34)

--- a/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
@@ -123,6 +123,18 @@ class WriteGraphTest extends FunSuite with BeforeAndAfter{
     assert(edges.collect.deep == expected)
   }
 
+  test ("Graphml produces correct output") {
+    val testLines = (0, 12, 30, 37)
+    val networkrdd = sc.parallelize(network)
+    WriteGraph.asGraphml(networkrdd, testFile)
+    assert(Files.exists(Paths.get(testFile)))
+    val lines = Source.fromFile(testFile).getLines.toList
+    assert(lines(testLines._1) == """<?xml version="1.0" encoding="UTF-8"?>""")
+    assert(lines(testLines._2) == """<data key="label">Source3"</data>""")
+    assert(lines(testLines._3) == """<data key="weight">3</data>""")
+    assert(lines(testLines._4) == """<edge source="0" target="5 type="directed">""")
+  }
+
   after {
     if (sc != null) {
       sc.stop()

--- a/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
@@ -81,7 +81,8 @@ class WriteGraphTest extends FunSuite with BeforeAndAfter{
     assert(lines(testLines._2) == """<node id="8d3ab53ec817a1e5bf9ffd6e749b3983" label="Destination2" />""")
     assert(lines(testLines._3) == """</attvalues>""")
     assert(lines(testLines._4) == """</edges>""")
-    assert(!WriteGraph.asGexf(networkarray ,""))
+    assert(!WriteGraph.asGexf(networkarray, ""))
+    assert(!WriteGraph(networkarray, ""))
   }
 
   test ("returns a Bool depending on pass or failure") {
@@ -107,6 +108,7 @@ class WriteGraphTest extends FunSuite with BeforeAndAfter{
     val badlookup = "NOTHERE"
     assert (WriteGraph.nodeLookup(nodes, badlookup) == None)
     assert (WriteGraph.nodeLookup(nodes, lookup) == Some((lookup, 6)))
+    assert (WriteGraph.nodeIdFromLabel(Option(null)) == -1)
   }
 
   test ("Gets the id from a lookup") {
@@ -161,6 +163,14 @@ class WriteGraphTest extends FunSuite with BeforeAndAfter{
     assert(lines(testLines._2) == """<node id="3" label="Source&lt;3" />""")
     assert(lines(testLines._3) == """<edge source="7" target="4" weight="4" type="directed">""")
     assert(lines(testLines._4) == """<attvalue for="0" value="Date2" />""")
+  }
+
+  test( "False on empty path") {
+    val networkrdd = sc.parallelize(network)
+    val emptyString = ""
+    assert(!WriteGraph(networkrdd, emptyString))
+    assert(!WriteGraph.asGraphml(networkrdd, emptyString))
+    assert(!WriteGraph.asGexf(networkrdd, emptyString))
   }
 
   after {


### PR DESCRIPTION
**GitHub issue(s)**:

#243

# What does this Pull Request do?

This PR adds WriteGraph which generates GEXF and/or Graphml files.
There are also some additional utilities such as an id lookup.

This object generates proper unique ids. This differs from the current method in WriteGraphML and WriteGEXF that simply creates ids using an MD5 hash of the url.  This method is better because the latter method could produce incorrect graphs in the case where hashes collide (eg. with very large graphs). 

Timing tests with a medium-sized graph shows that it increases the processing time by 10-15%. However, it could reduce the size of network graph derivatives by an unknown margin (because numeric ids are smaller than hashes).

Example:
Old way produces:
```
<node id="405d19a958ba43d88e9edd7a77338aa3" label="laws.justice.gc.ca" />
<node id="69bde2cbb357119a50a950fca99a8341" label="english.uvic.ca" />
<node id="8687e4dc11548a5917504975feb7c649" label="oipc.bc.ca" />
<node id="30192bae759dafccc58bccc268c2b411" label="accuweather.com" />
```
New way:
```
<node id="0" label="laws.justice.gc.ca" />
<node id="38" label="english.uvic.ca" />
<node id="76" label="oipc.bc.ca" />
<node id="114" label="accuweather.com" />
```
# How should this be tested?

- Travis should pass.

```
def timed(f: => Unit) = {
  val start = System.currentTimeMillis()
  f
  val end = System.currentTimeMillis()
  println("Elapsed Time: " + (end - start))
}

timed {
import io.archivesunleashed._
import io.archivesunleashed.app._
import io.archivesunleashed.matchbox._

val links = RecordLoader.loadArchives("/Users/ryandeschamps/warcs/", sc)
  .keepValidPages()
  .map(r => (r.getCrawlDate, ExtractLinks(r.getUrl, r.getContentString)))
  .flatMap(r => r._2.map(f => (r._1, ExtractDomain(f._1).replaceAll("^\\s*www\\.", ""), ExtractDomain(f._2).replaceAll("^\\s*www\\.", ""))))
  .filter(r => r._2 != "" && r._3 != "")
  .countItems()
  .filter(r => r._2 > 5)

WriteGraph(links, "new-gephi3.gexf") }
```

Should produce a Gexf that opens in Gephi.

Change last line to ```WriteGraph.asGraphml(links, "new-gephi3.gexf")``` to get graphml.

I have not tested it in GraphPass yet, but there is no reason why it should not work as directed.

# Additional Notes:

- `WriteGraphml`would replace WriteGEXF & WriteGraphml which can be deprecated.
- `CommandLineApp` would also have to be changed before WriteGEXF etc. are removed.
- I think aut had a previous `WriteGraph` udf which was deprecated and removed.
- This applies only to the RDD graph functions.  DF functions are not changed. (I need to review the way DFs do unique ids)
- I added a node id lookup tool during the process of developing WriteGraph. It might be useful for the toolkit, but it can also be removed.  

# Interested parties

@lintool @ruebot @ianmilligan1 

Thanks in advance for your help with the Archives Unleashed Toolkit!
