### PR TITLE
Add .getHttpStatus and .getFilename to ArchiveRecordImpl class #198 & #164

### DIFF
--- a/src/main/scala/io/archivesunleashed/ArchiveRecord.scala
+++ b/src/main/scala/io/archivesunleashed/ArchiveRecord.scala
@@ -31,8 +31,8 @@ import org.apache.commons.httpclient.{Header, HttpParser, StatusLine}
 
 /** Trait for a record in a web archive. */
 trait ArchiveRecord extends Serializable {
-  /** Returns the filename containing the Archive Records */
-  def getFilename: String
+  /** Returns the full path or url containing the Archive Records. */
+  def getResourcename: String
 
   /** Returns the crawl date. */
   def getCrawlDate: String
@@ -83,7 +83,7 @@ class ArchiveRecordImpl(r: SerializableWritable[ArchiveRecordWritable]) extends 
   }
   val ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX")
 
-  val getFilename: String = {
+  val getResourcename: String = {
     if (r.t.getFormat == ArchiveRecordWritable.ArchiveFormat.ARC){
       arcRecord.getMetaData.getReaderIdentifier()
     } else {

--- a/src/main/scala/io/archivesunleashed/ArchiveRecord.scala
+++ b/src/main/scala/io/archivesunleashed/ArchiveRecord.scala
@@ -32,7 +32,7 @@ import org.apache.commons.httpclient.{Header, HttpParser, StatusLine}
 /** Trait for a record in a web archive. */
 trait ArchiveRecord extends Serializable {
   /** Returns the filename containing the Archive Records */
-  def getFileName: String
+  def getFilename: String
 
   /** Returns the crawl date. */
   def getCrawlDate: String
@@ -83,7 +83,7 @@ class ArchiveRecordImpl(r: SerializableWritable[ArchiveRecordWritable]) extends 
   }
   val ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX")
 
-  val getFileName: String = {
+  val getFilename: String = {
     if (r.t.getFormat == ArchiveRecordWritable.ArchiveFormat.ARC){
       arcRecord.getMetaData.getReaderIdentifier()
     } else {

--- a/src/main/scala/io/archivesunleashed/ArchiveRecord.scala
+++ b/src/main/scala/io/archivesunleashed/ArchiveRecord.scala
@@ -32,7 +32,7 @@ import org.apache.commons.httpclient.{Header, HttpParser, StatusLine}
 /** Trait for a record in a web archive. */
 trait ArchiveRecord extends Serializable {
   /** Returns the full path or url containing the Archive Records. */
-  def getResourcename: String
+  def getArchiveFilename: String
 
   /** Returns the crawl date. */
   def getCrawlDate: String
@@ -83,7 +83,7 @@ class ArchiveRecordImpl(r: SerializableWritable[ArchiveRecordWritable]) extends 
   }
   val ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX")
 
-  val getResourcename: String = {
+  val getArchiveFilename: String = {
     if (r.t.getFormat == ArchiveRecordWritable.ArchiveFormat.ARC){
       arcRecord.getMetaData.getReaderIdentifier()
     } else {

--- a/src/main/scala/io/archivesunleashed/ArchiveRecord.scala
+++ b/src/main/scala/io/archivesunleashed/ArchiveRecord.scala
@@ -31,6 +31,9 @@ import org.apache.commons.httpclient.{Header, HttpParser, StatusLine}
 
 /** Trait for a record in a web archive. */
 trait ArchiveRecord extends Serializable {
+  /** Returns the filename containing the Archive Records */
+  def getFileName: String
+
   /** Returns the crawl date. */
   def getCrawlDate: String
 
@@ -79,6 +82,14 @@ class ArchiveRecordImpl(r: SerializableWritable[ArchiveRecordWritable]) extends 
       warcRecord = r.t.getRecord.asInstanceOf[WARCRecord]
   }
   val ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX")
+
+  val getFileName: String = {
+    if (r.t.getFormat == ArchiveRecordWritable.ArchiveFormat.ARC){
+      arcRecord.getMetaData.getReaderIdentifier()
+    } else {
+      warcRecord.getHeader.getReaderIdentifier()
+    }
+  }
 
   val getCrawlDate: String = {
     if (r.t.getFormat == ArchiveRecordWritable.ArchiveFormat.ARC){

--- a/src/test/scala/io/archivesunleashed/ArchiveRecordTest.scala
+++ b/src/test/scala/io/archivesunleashed/ArchiveRecordTest.scala
@@ -47,10 +47,10 @@ class ArchiveRecordTest extends FunSuite with BeforeAndAfter {
 
   test("Resource name produces expected result.") {
     val textSampleArc = RecordLoader.loadArchives(arcPath, sc)
-     .map(x => FilenameUtils.getName(x.getResourcename))
+     .map(x => FilenameUtils.getName(x.getArchiveFilename))
      .take(3)
     val textSampleWarc = RecordLoader.loadArchives(warcPath, sc)
-     .map(x => FilenameUtils.getName(x.getResourcename)).take(3)
+     .map(x => FilenameUtils.getName(x.getArchiveFilename)).take(3)
     assert(textSampleArc.deep == Array("example.arc.gz",
       "example.arc.gz", "example.arc.gz").deep)
     assert(textSampleWarc.deep == Array("example.warc.gz",

--- a/src/test/scala/io/archivesunleashed/ArchiveRecordTest.scala
+++ b/src/test/scala/io/archivesunleashed/ArchiveRecordTest.scala
@@ -37,11 +37,59 @@ class ArchiveRecordTest extends FunSuite with BeforeAndAfter {
       .setAppName(appName)
     conf.set("spark.driver.allowMultipleContexts", "true");
     sc = new SparkContext(conf)
+
   }
 
   test("count records") {
     assert(RecordLoader.loadArchives(arcPath, sc).count == 300L)
     assert(RecordLoader.loadArchives(warcPath, sc).count == 299L)
+  }
+
+  test("Crawl Dates") {
+    val textSampleArc = RecordLoader.loadArchives(arcPath, sc)
+     .map(x => x.getCrawlDate).take(3)
+    val textSampleWarc = RecordLoader.loadArchives(warcPath, sc)
+     .map(x => x.getCrawlDate).take(3)
+    assert(textSampleArc.deep == Array("20080430", "20080430", "20080430").deep)
+    assert(textSampleWarc.deep == Array("20080430", "20080430", "20080430").deep)
+  }
+
+  test("Domains") {
+    val textSampleArc = RecordLoader.loadArchives(arcPath, sc)
+     .map(x => x.getDomain).take(3)
+    val textSampleWarc = RecordLoader.loadArchives(warcPath, sc)
+     .map(x => x.getDomain).take(3)
+    assert(textSampleArc.deep == Array("", "", "www.archive.org").deep)
+    assert(textSampleWarc.deep == Array("", "www.archive.org", "www.archive.org").deep)
+  }
+
+  test("Urls") {
+    val textSampleArc = RecordLoader.loadArchives(arcPath, sc)
+     .map(x => x.getUrl).take(3)
+    val textSampleWarc = RecordLoader.loadArchives(warcPath, sc)
+     .map(x => x.getUrl).take(3)
+    assert(textSampleArc.deep == Array("filedesc://IAH-20080430204825-00000-blackbook.arc",
+      "dns:www.archive.org", "http://www.archive.org/robots.txt").deep)
+    assert(textSampleWarc.deep == Array("dns:www.archive.org",
+      "http://www.archive.org/robots.txt", "http://www.archive.org/").deep)
+  }
+
+  test("Mime-Type") {
+    val textSampleArc = RecordLoader.loadArchives(arcPath, sc)
+      .map(x => x.getMimeType).take(3)
+    val textSampleWarc = RecordLoader.loadArchives(warcPath, sc)
+      .map(x => x.getMimeType).take(3)
+    assert (textSampleArc.deep == Array ("text/plain", "text/dns", "text/plain").deep)
+    assert (textSampleWarc.deep == Array("unknown", "text/plain", "text/html").deep)
+  }
+
+  test("Get Http Status") {
+    val textSampleArc = RecordLoader.loadArchives(arcPath, sc)
+      .map(x => x.getHttpStatus).take(3)
+    val textSampleWarc = RecordLoader.loadArchives(warcPath, sc)
+      .map(x => x.getHttpStatus).take(3)
+    assert (textSampleArc.deep == Array("000", "000", "200").deep)
+    assert (textSampleWarc.deep == Array("000", "200", "200").deep)
   }
 
   after {
@@ -50,4 +98,3 @@ class ArchiveRecordTest extends FunSuite with BeforeAndAfter {
     }
   }
 }
-

--- a/src/test/scala/io/archivesunleashed/ArchiveRecordTest.scala
+++ b/src/test/scala/io/archivesunleashed/ArchiveRecordTest.scala
@@ -38,7 +38,6 @@ class ArchiveRecordTest extends FunSuite with BeforeAndAfter {
       .setAppName(appName)
     conf.set("spark.driver.allowMultipleContexts", "true");
     sc = new SparkContext(conf)
-
   }
 
   test("count records") {
@@ -46,12 +45,12 @@ class ArchiveRecordTest extends FunSuite with BeforeAndAfter {
     assert(RecordLoader.loadArchives(warcPath, sc).count == 299L)
   }
 
-  test("file name") {
+  test("Resource name produces expected result.") {
     val textSampleArc = RecordLoader.loadArchives(arcPath, sc)
-     .map(x => FilenameUtils.getName(x.getFilename))
+     .map(x => FilenameUtils.getName(x.getResourcename))
      .take(3)
     val textSampleWarc = RecordLoader.loadArchives(warcPath, sc)
-     .map(x => FilenameUtils.getName(x.getFilename)).take(3)
+     .map(x => FilenameUtils.getName(x.getResourcename)).take(3)
     assert(textSampleArc.deep == Array("example.arc.gz",
       "example.arc.gz", "example.arc.gz").deep)
     assert(textSampleWarc.deep == Array("example.warc.gz",

--- a/src/test/scala/io/archivesunleashed/ArchiveRecordTest.scala
+++ b/src/test/scala/io/archivesunleashed/ArchiveRecordTest.scala
@@ -48,10 +48,10 @@ class ArchiveRecordTest extends FunSuite with BeforeAndAfter {
 
   test("file name") {
     val textSampleArc = RecordLoader.loadArchives(arcPath, sc)
-     .map(x => FilenameUtils.getName(x.getFileName))
+     .map(x => FilenameUtils.getName(x.getFilename))
      .take(3)
     val textSampleWarc = RecordLoader.loadArchives(warcPath, sc)
-     .map(x => FilenameUtils.getName(x.getFileName)).take(3)
+     .map(x => FilenameUtils.getName(x.getFilename)).take(3)
     assert(textSampleArc.deep == Array("example.arc.gz",
       "example.arc.gz", "example.arc.gz").deep)
     assert(textSampleWarc.deep == Array("example.warc.gz",

--- a/src/test/scala/io/archivesunleashed/ArchiveRecordTest.scala
+++ b/src/test/scala/io/archivesunleashed/ArchiveRecordTest.scala
@@ -22,6 +22,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.apache.commons.io.FilenameUtils
 
 @RunWith(classOf[JUnitRunner])
 class ArchiveRecordTest extends FunSuite with BeforeAndAfter {
@@ -43,6 +44,18 @@ class ArchiveRecordTest extends FunSuite with BeforeAndAfter {
   test("count records") {
     assert(RecordLoader.loadArchives(arcPath, sc).count == 300L)
     assert(RecordLoader.loadArchives(warcPath, sc).count == 299L)
+  }
+
+  test("file name") {
+    val textSampleArc = RecordLoader.loadArchives(arcPath, sc)
+     .map(x => FilenameUtils.getName(x.getFileName))
+     .take(3)
+    val textSampleWarc = RecordLoader.loadArchives(warcPath, sc)
+     .map(x => FilenameUtils.getName(x.getFileName)).take(3)
+    assert(textSampleArc.deep == Array("example.arc.gz",
+      "example.arc.gz", "example.arc.gz").deep)
+    assert(textSampleWarc.deep == Array("example.warc.gz",
+      "example.warc.gz", "example.warc.gz").deep)
   }
 
   test("Crawl Dates") {


### PR DESCRIPTION

**GitHub issue(s)**:

#198, #164

# What does this Pull Request do?

This PR includes three changes to the ArchiveRecord class:
1. The Status Code Header for the crawl (via .getHttpStatus)
2. The read-streamed filename (via .getFilename)
3. Explicit testing of the ArchiveRecord class (this will likely not change coverage by much if at all).

`.getHttpStatus` could be useful for studies that would like to compare status calls on crawls.  

Example:

```scala
  import io.archivesunleashed._
  import io.archivesunleashed.matchbox._
  import io.archivesunleashed.util._

  val links = RecordLoader.loadArchives("/Users/ryandeschamps/warcs/*gz", sc)
    .keepValidPages()
    .keepContent(Set("apple".r))
    .map(r => (r.getHttpStatus, (ExtractLinks(r.getUrl, r.getContentString))))
    .flatMap(r => r._2.map(f => (r._1, ExtractDomain(f._1).replaceAll("^\\s*www\\.", ""), 
      ExtractDomain(f._2).replaceAll("^\\s*www\\.", ""))))
    .filter(r => r._2 != "" && r._3 != "")
    .countItems()
    .filter(r => r._2 > 5).take(10)
```
Should produce something like 

```
Array(((200,nanaimodailynews.com,nanaimodailynews.com),445785), ((200,nanaimodailynews.com,blackpress.ca),188676), ((200,nanaimodailynews.com,bclocalnews.com),111400), ... )
```

It might be more interesting to test this script without `.keepValidPages()` since most valid pages would likely return a `200`.  Where an ArchiveRecord fails to get a status code (via null or empty string) the record will return `000`.  This default value can be changed.

`.getFilename` returns the fullpath (which may be a url) of the Warc that was consumed.

```scala
  import io.archivesunleashed._
  import io.archivesunleashed.matchbox._
  import io.archivesunleashed.util._
  import org.apache.commons.io.FilenameUtils

  val links = RecordLoader.loadArchives("/Users/ryandeschamps/warcs/*gz", sc)
        .keepValidPages()
        .keepContent(Set("apple".r))
        .map(r => (r.getFilename, (ExtractLinks(r.getUrl, r.getContentString))))
        .flatMap(r => r._2.map(f => (r._1, ExtractDomain(f._1).replaceAll("^\\s*www\\.", ""), 
          ExtractDomain(f._2).replaceAll("^\\s*www\\.", ""))))
        .filter(r => r._2 != "" && r._3 != "")
        .countItems()
        .filter(r => r._2 > 5).take(10)

```

should produce something like 

```
links: Array[((String, String, String), Int)] = Array(((file:/Users/ryandeschamps/warcs/ARCHIVEIT-4656-CRAWL_SELECTED_SEEDS-JOB193391-20160127222913427-00000.warc.gz,nanaimodailynews.com,nanaimodailynews.com),439503), 
((file:/Users/ryandeschamps/warcs/ARCHIVEIT-4656-CRAWL_SELECTED_SEEDS-JOB193391-20160127222913427-00000.warc.gz,nanaimodailynews.com,blackpress.ca),186028), 
((file:/Users/ryandeschamps/warcs/ARCHIVEIT-4656-CRAWL_SELECTED_SEEDS-JOB193391-20160127222913427-00000.warc.gz,nanaimodailynews.com,bclocalnews.com),106107), 
((file:/Users/ryandeschamps/warcs/ARCHIVEIT-4656-CRAWL_SELECTED_SEEDS-JOB193391-20160127222913427-00000.warc.gz,nanaimodailynews.com,drivewaycanada.ca),53040),
...
```

To get just the filename, you could use `FilenameUtils.getName(x.getFilename)` (I have included the FilenameUtils import in the code above).  I have not looked into whether FilenameUtils will get the filename from a url, but that is why I stuck with the fullpath. Also, I am open to feedback on whether .getFilename is the right call for this.  IIPC calls it `.getReaderIdentifier()`.

I can think of a number of use cases for this, but it would be great as a way to detect problems with warcs (e.g. with wonky data).  It might also be helpful for error responses down the road.

# How should this be tested?

The above scripts should have expected outputs.
Both functions should work for both arc and warc formats.
Travis should pass.

# Additional Notes:

I used some of @dportabella 's ideas to produce the code here, in particular for getting the HttpStatus from a Warc file. For Arc and the Warc filename, I tried to use the WARCRecord and ARCRecord classes instead.

I did not include the full header responses in this PR. It seems like the ArcRecord and WarcRecord responses are quite different and I haven't been able to produce an effective testing mechanism.

# Interested parties

@ianmilligan1 @ruebot 


Thanks in advance for your help with the Archives Unleashed Toolkit!
