### PR TITLE
Update for Tika CVE-2018-17197.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -573,12 +573,12 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
-      <version>1.19.1</version>
+      <version>[1.20,)</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
-      <version>1.19.1</version>
+      <version>[1.20,)</version>
     </dependency>
     <dependency>
       <groupId>org.rogach</groupId>


### PR DESCRIPTION
# What does this Pull Request do?

Updates Tika dependencies to [1.20,) for [CVE-2018-17197](https://nvd.nist.gov/vuln/detail)./CVE-2018-17197

# How should this be tested?

- Clean build; TravisCI should take care of that. Green should be good to merge.