### PR TITLE
Log closing of ARC and WARC files, per #156

### DIFF
--- a/src/main/java/io/archivesunleashed/data/ArchiveRecordInputFormat.java
+++ b/src/main/java/io/archivesunleashed/data/ArchiveRecordInputFormat.java
@@ -138,7 +138,6 @@ public class ArchiveRecordInputFormat extends FileInputFormat<LongWritable,
       FSDataInputStream fileIn = fs.open(split.getPath());
       fileName = split.getPath().toString();
 
-      LOG.info("Opening archive file " + fileName);
       reader = ArchiveReaderFactory.get(fileName,
           new BufferedInputStream(fileIn), true);
 

--- a/src/main/java/io/archivesunleashed/data/ArchiveRecordInputFormat.java
+++ b/src/main/java/io/archivesunleashed/data/ArchiveRecordInputFormat.java
@@ -47,24 +47,24 @@ import java.util.Iterator;
  * Extends FileInputFormat for Web Archive Commons InputFormat.
  */
 public class ArchiveRecordInputFormat extends FileInputFormat<LongWritable,
-        ArchiveRecordWritable> {
+  ArchiveRecordWritable> {
   /**
    * Setup logger.
    */
-  private static final Logger LOG =
-          Logger.getLogger(ArchiveRecordInputFormat.class);
+  private static final Logger LOG = 
+    Logger.getLogger(ArchiveRecordInputFormat.class);
 
   @Override
   public final RecordReader<LongWritable,
-          ArchiveRecordWritable> createRecordReader(final InputSplit split,
-                                                    final TaskAttemptContext context) throws IOException,
-          InterruptedException {
+    ArchiveRecordWritable> createRecordReader(final InputSplit split,
+      final TaskAttemptContext context) throws IOException,
+  InterruptedException {
     return new ArchiveRecordReader();
   }
 
   @Override
   protected final boolean isSplitable(final JobContext context,
-                                      final Path filename) {
+          final Path filename) {
     return false;
   }
 
@@ -72,7 +72,7 @@ public class ArchiveRecordInputFormat extends FileInputFormat<LongWritable,
    * Extends RecordReader for Record Reader.
    */
   public class ArchiveRecordReader extends RecordReader<LongWritable,
-          ArchiveRecordWritable> {
+    ArchiveRecordWritable> {
 
     /**
      * Archive reader.
@@ -126,8 +126,8 @@ public class ArchiveRecordInputFormat extends FileInputFormat<LongWritable,
 
     @Override
     public final void initialize(final InputSplit archiveRecordSplit,
-                                 final TaskAttemptContext context)
-            throws IOException {
+            final TaskAttemptContext context)
+    throws IOException {
       FileSplit split = (FileSplit) archiveRecordSplit;
       Configuration job = context.getConfiguration();
       start = split.getStart();
@@ -140,7 +140,7 @@ public class ArchiveRecordInputFormat extends FileInputFormat<LongWritable,
 
       LOG.info("Opening archive file " + fileName);
       reader = ArchiveReaderFactory.get(fileName,
-              new BufferedInputStream(fileIn), true);
+          new BufferedInputStream(fileIn), true);
 
       if (reader instanceof ARCReader) {
         format = ArchiveFormat.ARC;

--- a/src/main/java/io/archivesunleashed/data/ArchiveRecordInputFormat.java
+++ b/src/main/java/io/archivesunleashed/data/ArchiveRecordInputFormat.java
@@ -51,7 +51,7 @@ public class ArchiveRecordInputFormat extends FileInputFormat<LongWritable,
   /**
    * Setup logger.
    */
-  private static final Logger LOG = 
+  private static final Logger LOG =
     Logger.getLogger(ArchiveRecordInputFormat.class);
 
   @Override


### PR DESCRIPTION
**GitHub issue(s)**: #156 

# What does this Pull Request do?
* Adds log message (level "INFO") indicating when an ARC or WARC file that has been read has been closed.

# How should this be tested?

In Spark shell:

```
scala> sc.setLogLevel("INFO")

scala> :paste
// Entering paste mode (ctrl-D to finish)

import io.archivesunleashed._
import io.archivesunleashed.matchbox._

val r = RecordLoader.loadArchives("/PATH/TO/test-classes/arc/*.arc.gz", sc)
.keepValidPages()
.map(r => ExtractDomain(r.getUrl))
.countItems()
.take(10)
```

The logs should contain something similar to this:
```
2019-01-30 11:10:04 INFO  NewHadoopRDD:54 - Input split: file:/home/jrwiebe/aut/target/test-classes/arc/badexample.arc.gz:0+1221
2019-01-30 11:10:04 INFO  NewHadoopRDD:54 - Input split: file:/home/jrwiebe/aut/target/test-classes/arc/example.arc.gz:0+2012526
WARNING Record STARTING at 0 has 1761 trailing byte(s): file:/home/jrwiebe/aut/target/test-classes/arc/badexample.arc.gz: {subject-uri=filedesc://IAH-20080430204825-00000-blackbook.arc, ip-address=0.0.0.0, origin=InternetArchive, length=1300, absolute-offset=0, creation-date=20080430204825, content-type=text/plain, version=1.1}
2019-01-30 11:10:05 INFO  ArchiveRecordInputFormat:240 - Closed archive file file:/home/jrwiebe/aut/target/test-classes/arc/badexample.arc.gz
```
# Additional Notes:

# Interested parties

@dportabella 
