### PR TITLE
Resolve cobertura-maven-plugin class issue; resolves #313.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,19 +201,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- for codecov.io -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <formats>
-            <format>html</format>
-            <format>xml</format>
-          </formats>
-          <check />
-        </configuration>
-      </plugin>
       <!-- for mycila -->
       <plugin>
         <groupId>com.mycila</groupId>
@@ -687,6 +674,19 @@
       <version>3.2</version>
     </dependency>
     <!--END issue #113-->
+    <!-- for codecov.io -->
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>cobertura-maven-plugin</artifactId>
+      <version>2.7</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <developers>


### PR DESCRIPTION
**GitHub issue(s)**:
* #313 

# What does this Pull Request do?

Exclude slf4j binding logback-classic
(https://github.com/mojohaus/cobertura-maven-plugin/issues/6#issuecomment-311590980)

# How should this be tested?

* Test should pass
* We should still get a codecov.io report
* If you build locally, (`rm ~/.m2/repository/* ~/.ivy2 && mvn clean install`), then;
* We shouldn't see the classpath issue in #313 when using `--jars`

# Interested parties

@edsu
