### PR TITLE
Updates to pom following 0e701b271e04e60c6fa89f39299dae7142d700b8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project_name>${project.artifactId}</project_name>
     <project_organization>The Archives Unleashed Project</project_organization>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <hadoop.version>2.6.5</hadoop.version>
     <spark.version>2.4.3</spark.version>
     <github.global.server>github</github.global.server>
@@ -456,7 +456,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_2.11</artifactId>
-      <version>3.0.1</version>
+      <version>3.0.8</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -472,7 +472,7 @@
     <dependency>
       <groupId>com.chuusai</groupId>
       <artifactId>shapeless_2.11</artifactId>
-      <version>2.3.2</version>
+      <version>2.3.3</version>
       <exclusions>
         <exclusion>
           <groupId>org.typelevel</groupId>
@@ -483,7 +483,7 @@
     <dependency>
       <groupId>org.scala-lang.modules</groupId>
       <artifactId>scala-parser-combinators_2.11</artifactId>
-      <version>1.0.5</version>
+      <version>1.1.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -587,11 +587,6 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-graphx_2.11</artifactId>
       <version>${spark.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>15.0</version>
     </dependency>
     <dependency>
       <groupId>org.xerial.snappy</groupId>

--- a/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/WriteGraphTest.scala
@@ -105,7 +105,7 @@ class WriteGraphTest extends FunSuite with BeforeAndAfter{
     val networkrdd = sc.parallelize(network)
     val nodes = WriteGraph.nodesWithIds(networkrdd)
     val lookup = "Source1"
-    val badlookup = "NOTHERE"
+    val badlookup = "NOTTHERE"
     assert (WriteGraph.nodeLookup(nodes, badlookup) == None)
     assert (WriteGraph.nodeLookup(nodes, lookup) == Some((lookup, 6)))
     assert (WriteGraph.nodeIdFromLabel(Option(null)) == -1)


### PR DESCRIPTION
# What does this Pull Request do?

- Remove explicit Guava dependency (should have been remove in
0e701b271e04e60c6fa89f39299dae7142d700b8)
- Update Scala to 2.11.12; aligns with Spark 2.4.3
- Update Scala test
- Update Shapeless
- Update Scala lang parsers
- Fix a typo in a test

The updates are mostly to get `aut` back to a place where we don't have mixed Scala version warnings. However, as I dug deeper into getting everything up to 2.11.12 we ran into lots of problems. This gets us part of the way there, and we can come back later should we want to.

# How should this be tested?

- TravisCI
- I tested locally with a language extraction and full text text extraction scripts.

