### PR TITLE
Enable S3 access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,9 @@
               <shadedClassifierName>fatjar</shadedClassifierName>
               <artifactSet>
                 <excludes>
-                  <exclude>org.apache.hadoop:*</exclude>
+                  <exclude>org.apache.hadoop:hadoop-core</exclude>
+                  <exclude>org.apache.hadoop:hadoop-common</exclude>
+		  <exclude>org.apache.hadoop:hadoop-mapreduce-client-core</exclude>
                   <exclude>org.apache.spark:*</exclude>
                 </excludes>
               </artifactSet>
@@ -742,6 +744,11 @@
           <artifactId>logback-classic</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>${hadoop.version}</version>
     </dependency>
   </dependencies>
 

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -22,6 +22,7 @@ import ArchiveRecordWritable.ArchiveFormat
 import io.archivesunleashed.matchbox.{ComputeMD5, DetectLanguage, ExtractDate, ExtractDomain, ExtractImageDetails, ExtractImageLinks, ExtractLinks, RemoveHTML}
 import io.archivesunleashed.matchbox.ImageDetails
 import io.archivesunleashed.matchbox.ExtractDate.DateComponent
+import java.net.URI
 import org.apache.hadoop.fs.{FileSystem, Path}
 // scalastyle:off underscore.import
 import io.archivesunleashed.matchbox.ExtractDate.DateComponent._
@@ -59,7 +60,8 @@ package object archivesunleashed {
       * @return an RDD of ArchiveRecords for mapping.
       */
     def loadArchives(path: String, sc: SparkContext): RDD[ArchiveRecord] = {
-      val fs = FileSystem.get(sc.hadoopConfiguration)
+      val uri = new URI(path)
+      val fs = FileSystem.get(uri, sc.hadoopConfiguration)
       val p = new Path(path)
       sc.newAPIHadoopFile(getFiles(p, fs), classOf[ArchiveRecordInputFormat], classOf[LongWritable], classOf[ArchiveRecordWritable])
         .filter(r => (r._2.getFormat == ArchiveFormat.ARC) ||


### PR DESCRIPTION
This PR responds to issue #319. It enables access to data stored in S3 by including necessary dependencies, and changing how the FileSystem is detected in `RecordLoader.loadArchives`. See the issue discussion for a description of the two scenarios where AWS authentication currently fails due to reliance on an outdated version of Hadoop (i.e., use of temporary credentials, and Signature Version 4). This can be tested with the example code provided in the issue.