### PR TITLE
Make ArchiveRecord.getContentBytes consistent, Resolve #334

### DIFF
--- a/src/main/scala/io/archivesunleashed/ArchiveRecord.scala
+++ b/src/main/scala/io/archivesunleashed/ArchiveRecord.scala
@@ -107,7 +107,7 @@ class ArchiveRecordImpl(r: SerializableWritable[ArchiveRecordWritable]) extends 
   val getContentBytes: Array[Byte] = {
     if (recordFormat == ArchiveRecordWritable.ArchiveFormat.ARC)
     {
-      ArcRecordUtils.getBodyContent(r.t.getRecord.asInstanceOf[ARCRecord])
+      ArcRecordUtils.getContent(r.t.getRecord.asInstanceOf[ARCRecord])
     } else {
       WarcRecordUtils.getContent(r.t.getRecord.asInstanceOf[WARCRecord])
     }

--- a/src/test/scala/io/archivesunleashed/ArcTest.scala
+++ b/src/test/scala/io/archivesunleashed/ArcTest.scala
@@ -92,7 +92,7 @@ class ArcTest extends FunSuite with BeforeAndAfter {
       .collect
 
     languageCounts.foreach {
-      case ("en", count) => assert(135L == count)
+      case ("en", count) => assert(140L == count)
       case ("et", count) => assert(6L == count)
       case ("it", count) => assert(1L == count)
       case ("lt", count) => assert(61L == count)
@@ -115,11 +115,11 @@ class ArcTest extends FunSuite with BeforeAndAfter {
       case ("image/png", count) => assert(8L == count)
       case ("image/jpeg", count) => assert(18L == count)
       case ("text/html", count) => assert(132L == count)
-      case ("text/plain", count) => assert(229L == count)
+      case ("text/plain", count) => assert(237L == count)
       case ("application/xml", count) => assert(1L == count)
       case ("application/rss+xml", count) => assert(9L == count)
       case ("application/xhtml+xml", count) => assert(1L == count)
-      case ("application/octet-stream", count) => assert(26L == count)
+      case ("application/octet-stream", count) => assert(63L == count)
       case ("application/x-shockwave-flash", count) => assert(8L == count)
       case (_, count) => print(_)
     }


### PR DESCRIPTION
**GitHub issue(s)**:

#334

# What does this Pull Request do?

As noted in #334, @jrwiebe discovered that we are inconsistent on how we `getContentBytes` of ARC and WARC files. Currently, ARC files we just get the contents of the record (using `getBodyContent`) and WARC files we get everything (using `getContent`). The two should be consistent.

On the ticket itself, I discussed the various outputs, how they differ, and potential solutions. I think it is critical that we normalize the two approaches. Given the existence of `RemoveHttpHeader`, I think we should have both just using `getContent`. If people just want the body content, they can remove the header (which is what we've been doing with WARC files). I can imagine lots of diverse use cases for HTTP header information so it's better to have it in there and then remove it.

# How should this be tested?

- TravisCI _should_ turn green. Note that I had to change the tests because now that we are returning headers in the ARC files, the tika and language counts are different. This is to be expected, to me at least.
- We should do some sanity checking on the outputs.

# Additional Notes:

We should probably foreground `RemoveHttpHeader` more in our documentation. 

# Interested parties

@ruebot @jrwiebe 
