### PR TITLE
Use Tika's detected MIME type instead of ArchiveRecord getMimeType.

### DIFF
--- a/src/test/scala/io/archivesunleashed/df/DataFrameLoaderTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/DataFrameLoaderTest.scala
@@ -34,7 +34,7 @@ class DataFrameLoaderTest extends FunSuite with BeforeAndAfter {
   private val appName = "example-df"
   private var sc: SparkContext = _
   private val url = "url"
-  private val mime_type = "mime_type"
+  private val mime_type = "mime_type_web_server"
   private val md5 = "md5"
 
   before {

--- a/src/test/scala/io/archivesunleashed/df/ExtractAudioDetailsTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractAudioDetailsTest.scala
@@ -46,14 +46,16 @@ class ExtractAudioDetailsTest extends FunSuite with BeforeAndAfter {
     val df = RecordLoader.loadArchives(warcPath, sc)
       .extractAudioDetailsDF()
 
-    val extracted = df.select("url", "filename", "extension", "mime_type", "md5")
+    val extracted = df.select("url", "filename", "extension",
+      "mime_type_web_server", "mime_type_tika", "md5")
       .orderBy(desc("md5")).head(1).toList
     assert(extracted.size == 1)
     assert("https://ruebot.net/files/feniz.mp3" == extracted(0)(0))
     assert("feniz.mp3" == extracted(0)(1))
     assert("mp3" == extracted(0)(2))
     assert("audio/mpeg" == extracted(0)(3))
-    assert("f7e7ec84b12c294e19af1ba41732c733" == extracted(0)(4))
+    assert("audio/mpeg" == extracted(0)(4))
+    assert("f7e7ec84b12c294e19af1ba41732c733" == extracted(0)(5))
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractImageDetailsTest.scala
@@ -46,17 +46,20 @@ class ExtractImageDetailsTest extends FunSuite with BeforeAndAfter {
     val df = RecordLoader.loadArchives(arcPath, sc)
       .extractImageDetailsDF()
 
-    val extracted = df.select("url", "mime_type", "width", "height", "md5")
+    val extracted = df.select("url", "mime_type_web_server", "mime_type_tika",
+      "width", "height", "md5")
       .orderBy(desc("md5")).head(2).toList
     assert(extracted.size == 2)
     assert("http://www.archive.org/images/mediatype_movies.gif" == extracted(0)(0))
     assert("image/gif" == extracted(0)(1))
-    assert(21 == extracted(0)(2))
+    assert("image/gif" == extracted(0)(2))
     assert(21 == extracted(0)(3))
+    assert(21 == extracted(0)(4))
     assert("http://www.archive.org/images/LOCLogoSmall.jpg" == extracted(1)(0))
     assert("image/jpeg" == extracted(1)(1))
-    assert(275 == extracted(1)(2))
-    assert(300 == extracted(1)(3))
+    assert("image/jpeg" == extracted(1)(2))
+    assert(275 == extracted(1)(3))
+    assert(300 == extracted(1)(4))
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/df/ExtractPDFDetailsTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractPDFDetailsTest.scala
@@ -46,19 +46,22 @@ class ExtractPDFDetailsTest extends FunSuite with BeforeAndAfter {
     val df = RecordLoader.loadArchives(warcPath, sc)
       .extractPDFDetailsDF()
 
-    val extracted = df.select("url", "filename", "extension", "mime_type", "md5")
+    val extracted = df.select("url", "filename", "extension",
+      "mime_type_web_server", "mime_type_tika", "md5")
       .orderBy(desc("md5")).head(2).toList
     assert(extracted.size == 2)
     assert("https://yorkspace.library.yorku.ca/xmlui/bitstream/handle/10315/36158/cost-analysis.pdf?sequence=1&isAllowed=y" == extracted(0)(0))
     assert("cost-analysis.pdf" == extracted(0)(1))
     assert("pdf" == extracted(0)(2))
     assert("application/pdf" == extracted(0)(3))
-    assert("aaba59d2287afd40c996488a39bbc0dd" == extracted(0)(4))
+    assert("application/pdf" == extracted(0)(4))
+    assert("aaba59d2287afd40c996488a39bbc0dd" == extracted(0)(5))
     assert("https://yorkspace.library.yorku.ca/xmlui/bitstream/handle/10315/36158/JCDL%20-%20Cost%20of%20a%20WARC%20Presentation-4.pdf?sequence=3&isAllowed=y" == extracted(1)(0))
     assert("JCDL%20-%20Cost%20of%20a%20WARC%20Presentation-4.pdf" == extracted(1)(1))
     assert("pdf" == extracted(1)(2))
     assert("application/pdf" == extracted(1)(3))
-    assert("322cd5239141408c42f7441f15eed9af" == extracted(1)(4))
+    assert("application/pdf" == extracted(1)(4))
+    assert("322cd5239141408c42f7441f15eed9af" == extracted(1)(5))
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/df/ExtractVideoDetailsTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractVideoDetailsTest.scala
@@ -46,14 +46,16 @@ class ExtractVideoDetailsTest extends FunSuite with BeforeAndAfter {
     val df = RecordLoader.loadArchives(warcPath, sc)
       .extractVideoDetailsDF()
 
-    val extracted = df.select("url", "filename", "extension", "mime_type", "md5")
+    val extracted = df.select("url", "filename", "extension",
+      "mime_type_web_server", "mime_type_tika", "md5")
       .orderBy(desc("md5")).head(1).toList
     assert(extracted.size == 1)
     assert("https://ruebot.net/2018-11-12%2016.14.11.mp4" == extracted(0)(0))
     assert("2018-11-12%2016.14.11.mp4" == extracted(0)(1))
     assert("mp4" == extracted(0)(2))
     assert("video/mp4" == extracted(0)(3))
-    assert("2cde7de3213a87269957033f6315fce2" == extracted(0)(4))
+    assert("video/mp4" == extracted(0)(4))
+    assert("2cde7de3213a87269957033f6315fce2" == extracted(0)(5))
   }
 
   after {


### PR DESCRIPTION
**GitHub issue(s)**: #342

# What does this Pull Request do?

- Move audio, pdf, and video DF extraction to tuple map
- Provide two MimeType columns; mime_type_web_server and mime_type_tika
- Update tests
- Resolves #342

# How should this be tested?

- TravisCI
- I did the same tests for #341 and got the same number of files before and after for the 10 GeoCities WARCs:

```
4809 audio files
644 PDF files
232 video files
5685 total
```

Times were slightly slower :man_shrugging:

- This PR `4212.43s user 224.14s system 623% cpu 11:51.81 total`
- HEAD on master now: `3899.34s user 186.65s system 598% cpu 11:23.12 total`

# Interested parties

@jrwiebe @ianmilligan1 
