### PR TITLE
Add binary extraction DataFrames to PySpark.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Ok! Take a quick spin with `aut` with [Docker](https://github.com/archivesunleas
 
 ## Documentation! Or, how do I use this?
 
-Once built or downloaded, you can follow the basic set of recipes and tutorials [here](http://archivesunleashed.org/aut/).
+Once built or downloaded, you can follow the basic set of recipes and tutorials [here](https://github.com/archivesunleashed/aut/wiki/User-Documentation).
 
 # License
 
@@ -67,4 +67,6 @@ Licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/
 
 # Acknowledgments
 
-This work is primarily supported by the [Andrew W. Mellon Foundation](https://uwaterloo.ca/arts/news/multidisciplinary-project-will-help-historians-unlock). Additional funding for the Toolkit has come from the U.S. National Science Foundation, Columbia University Library's Mellon-funded Web Archiving Incentive Award, the Natural Sciences and Engineering Research Council of Canada, the Social Sciences and Humanities Research Council of Canada, and the Ontario Ministry of Research and Innovation's Early Researcher Award program. Any opinions, findings, and conclusions or recommendations expressed are those of the researchers and do not necessarily reflect the views of the sponsors.
+This work is primarily supported by the [Andrew W. Mellon Foundation](https://mellon.org/). Other financial and in-kind support comes from the [Social Sciences and Humanities Research Council](http://www.sshrc-crsh.gc.ca/), [Compute Canada](https://www.computecanada.ca/), the [Ontario Ministry of Research, Innovation, and Science](https://www.ontario.ca/page/ministry-research-innovation-and-science), [York University Libraries](https://www.library.yorku.ca/web/), [Start Smart Labs](http://www.startsmartlabs.com/), and the [Faculty of Arts](https://uwaterloo.ca/arts/) and [David R. Cheriton School of Computer Science](https://cs.uwaterloo.ca/) at the [University of Waterloo](https://uwaterloo.ca/).
+
+Any opinions, findings, and conclusions or recommendations expressed are those of the researchers and do not necessarily reflect the views of the sponsors.

--- a/src/main/python/aut/common.py
+++ b/src/main/python/aut/common.py
@@ -13,3 +13,30 @@ class WebArchive:
 
     def links(self):
         return DataFrame(self.loader.extractHyperlinks(self.path), self.sqlContext)
+
+    def images(self):
+        return DataFrame(self.loader.extractImages(self.path), self.sqlContext)
+
+    def image_links(self):
+        return DataFrame(self.loader.extractImageLinks(self.path), self.sqlContext)
+
+    def pdfs(self):
+        return DataFrame(self.loader.extractPDFs(self.path), self.sqlContext)
+
+    def audio(self):
+        return DataFrame(self.loader.extractAudio(self.path), self.sqlContext)
+
+    def video(self):
+        return DataFrame(self.loader.extractVideo(self.path), self.sqlContext)
+
+    def spreadsheets(self):
+        return DataFrame(self.loader.extractSpreadsheets(self.path), self.sqlContext)
+
+    def presentation_program(self):
+        return DataFrame(self.loader.extractPresentationProgram(self.path), self.sqlContext)
+
+    def word_processor(self):
+        return DataFrame(self.loader.extractWordProcessor(self.path), self.sqlContext)
+
+    def text_files(self):
+        return DataFrame(self.loader.extractTextFiles(self.path), self.sqlContext)

--- a/src/main/scala/io/archivesunleashed/DataFrameLoader.scala
+++ b/src/main/scala/io/archivesunleashed/DataFrameLoader.scala
@@ -21,25 +21,69 @@ import org.apache.spark.SparkContext
 import org.apache.spark.sql.DataFrame
 
 class DataFrameLoader(sc: SparkContext) {
+
+  /** Create a DataFram with crawl_date, url, mime_type_web_server, and content. */
   def extractValidPages(path: String): DataFrame = {
     RecordLoader.loadArchives(path, sc)
       .extractValidPagesDF()
   }
 
+  /** Create a DataFrame with crawl_date, source, destination, and anchor. */
   def extractHyperlinks(path: String): DataFrame = {
     RecordLoader.loadArchives(path, sc)
       .extractHyperlinksDF()
   }
 
-  /* Create a dataframe with (source page, image url) pairs */
+  /* Create a DataFrame with source page, and image url. */
   def extractImageLinks(path: String): DataFrame = {
     RecordLoader.loadArchives(path, sc)
       .extractImageLinksDF()
   }
 
-  /** Create a dataframe with (image url, type, width, height, md5, raw bytes) pairs */
+  /** Create a DataFrame with image url, filename, extension, mime_type_web_servr, mime_type_tika, width, height, md5, and raw bytes. */
   def extractImages(path: String): DataFrame = {
     RecordLoader.loadArchives(path, sc)
       .extractImageDetailsDF()
+  }
+
+  /** Create a DataFrame with PDF url, filename, extension, mime_type_web_servr, mime_type_tika, md5, and raw bytes. */
+  def extractPDFs(path: String): DataFrame = {
+    RecordLoader.loadArchives(path, sc)
+    .extractPDFDetailsDF
+  }
+  /** Create a DataFrame with audio url, filename, extension, mime_type_web_servr, mime_type_tika, md5, and raw bytes. */
+  def extractAudio(path: String): DataFrame = {
+    RecordLoader.loadArchives(path, sc)
+    .extractAudioDetailsDF
+  }
+
+  /** Create a DataFrame with video url, filename, extension, mime_type_web_servr, mime_type_tika, md5, and raw bytes. */
+  def extractVideo(path: String): DataFrame = {
+    RecordLoader.loadArchives(path, sc)
+    .extractVideoDetailsDF
+  }
+
+  /** Create a DataFrame with spreadsheet url, filename, extension, mime_type_web_servr, mime_type_tika, md5, and raw bytes. */
+  def extractSpreadsheets(path: String): DataFrame = {
+    RecordLoader.loadArchives(path, sc)
+    .extractSpreadsheetDetailsDF
+  }
+
+  /** Create a DataFrame with presentation program url, filename, extension, mime_type_web_servr, mime_type_tika, md5, and raw bytes. */
+  def extractPresentationProgram(path: String): DataFrame = {
+    RecordLoader.loadArchives(path, sc)
+    .extractPresentationProgramDetailsDF
+  }
+
+  /** Create a DataFrame with word processor url, filename, extension, mime_type_web_servr, mime_type_tika, md5, and raw bytes. */
+  def extractWordProcessor(path: String): DataFrame = {
+    RecordLoader.loadArchives(path, sc)
+    .extractWordProcessorDetailsDF
+  }
+
+  /** Create a DataFrame with text file url, filename, extension, mime_type_web_servr, mime_type_tika, md5, and raw bytes. */
+  def extractTextFiles(path: String): DataFrame = {
+    RecordLoader.loadArchives(path, sc)
+    .extractTextFilesDetailsDF
   }
 }


### PR DESCRIPTION
**GitHub issue(s)**:

- #190
- #259
- #302
- #303
- #304
- #305
- #306
- #307

# What does this Pull Request do?

Add binary extraction DataFrames to PySpark.

# How should this be tested?

- TravisCI
- Fire up a Jupyter Notebook:
```
$ PYSPARK_DRIVER_PYTHON=jupyter PYSPARK_DRIVER_PYTHON_OPTS=notebook ~/bin/spark-2.4.3-bin-hadoop2.7/bin/pyspark --jars /home/nruest/Projects/au/aut/target/aut-0.17.1-SNAPSHOT-fatjar.jar --driver-class-path /home/nruest/Projects/au/aut/target/aut-0.17.1-SNAPSHOT-fatjar.jar --py-files /home/nruest/Projects/au/aut/target/aut.zip
```

Then do this for each of the additions, and make sure it works:

```
from aut import *

archive = WebArchive(sc, sqlContext, "/home/nruest/Projects/au/aut/src/test/resources/warc/")

df = archive.spreadsheets()
df.printSchema()
```

![Screenshot from 2019-08-20 13-25-51](https://user-images.githubusercontent.com/218561/63369478-0cbba400-c34e-11e9-880c-f55b9648f44f.png)


# Additional Notes:

Let's see what happens with the test coverage. I assume I'm going to have to add some things to `src/test/scala/io/archivesunleashed/df/DataFrameLoaderTest.scala`