### PR TITLE
Various UDF implementation and cleanup for DF

### DIFF
--- a/src/main/scala/io/archivesunleashed/app/DomainFrequencyExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/DomainFrequencyExtractor.scala
@@ -47,7 +47,7 @@ object DomainFrequencyExtractor {
     import spark.implicits._
     // scalastyle:on
 
-    d.select(df.ExtractBaseDomain($"url").as("domain"))
+    d.select(df.ExtractDomain($"url").as("domain"))
       .groupBy("domain").count().orderBy(desc("count"))
   }
 }

--- a/src/main/scala/io/archivesunleashed/app/DomainGraphExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/DomainGraphExtractor.scala
@@ -55,8 +55,8 @@ object DomainGraphExtractor {
     import spark.implicits._
     // scalastyle:on
     d.select($"crawl_date",
-      df.RemovePrefixWWW(df.ExtractBaseDomain($"src")).as("src_domain"),
-      df.RemovePrefixWWW(df.ExtractBaseDomain($"dest")).as("dest_domain"))
+      df.RemovePrefixWWW(df.ExtractDomain($"src")).as("src_domain"),
+      df.RemovePrefixWWW(df.ExtractDomain($"dest")).as("dest_domain"))
       .filter("src_domain != ''").filter("dest_domain != ''")
       .groupBy($"crawl_date", $"src_domain", $"dest_domain").count().orderBy(desc("count"))
   }

--- a/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
@@ -44,7 +44,7 @@ object PlainTextExtractor {
     // scalastyle:off
     import spark.implicits._
     // scalastyle:on
-    d.select($"crawl_date", df.ExtractBaseDomain($"url").as("domain"),
+    d.select($"crawl_date", df.ExtractDomain($"url").as("domain"),
       $"url", df.RemoveHTML($"content").as("Text"))
   }
 }

--- a/src/main/scala/io/archivesunleashed/df/package.scala
+++ b/src/main/scala/io/archivesunleashed/df/package.scala
@@ -31,7 +31,9 @@ package object df {
   // by wrapping matchbox UDFs or by reimplementing them. The following examples illustrate. Obviously, we'll
   // need to populate more UDFs over time, but this is a start.
 
-  val ExtractBaseDomain = udf(io.archivesunleashed.matchbox.ExtractDomain.apply(_: String, ""))
+  val ExtractDomain = udf(io.archivesunleashed.matchbox.ExtractDomain.apply(_: String, ""))
+
+  val RemoveHttpHeader = udf(io.archivesunleashed.matchbox.RemoveHttpHeader.apply(_: String))
 
   val RemovePrefixWWW = udf[String, String](_.replaceAll("^\\s*www\\.", ""))
 

--- a/src/main/scala/io/archivesunleashed/matchbox/RemoveHTML.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/RemoveHTML.scala
@@ -27,7 +27,8 @@ object RemoveHTML {
    * @return content without html markup.
    */
   def apply(content: String): String = {
-    val maybeContent: Option[String] = Option(content)
+    // First remove the HTTP header.
+    val maybeContent: Option[String] = Option(RemoveHttpHeader(content))
     maybeContent match {
       case Some(content) =>
         Jsoup.parse(content).text().replaceAll("[\\r\\n]+", " ")

--- a/src/test/scala/io/archivesunleashed/ArcTest.scala
+++ b/src/test/scala/io/archivesunleashed/ArcTest.scala
@@ -91,7 +91,7 @@ class ArcTest extends FunSuite with BeforeAndAfter {
       .collect
 
     languageCounts.foreach {
-      case ("en", count) => assert(140L == count)
+      case ("en", count) => assert(135L == count)
       case ("et", count) => assert(6L == count)
       case ("it", count) => assert(1L == count)
       case ("lt", count) => assert(61L == count)
@@ -103,7 +103,7 @@ class ArcTest extends FunSuite with BeforeAndAfter {
 
   test("detect mime type tika") {
     val mimeTypeCounts = RecordLoader.loadArchives(arcPath, sc)
-      .map(r => RemoveHTML(r.getContentString))
+      .map(r => RemoveHttpHeader(r.getContentString))
       .groupBy(content => DetectMimeTypeTika(content.getBytes))
       .map(f => {
         (f._1, f._2.size)
@@ -114,11 +114,11 @@ class ArcTest extends FunSuite with BeforeAndAfter {
       case ("image/png", count) => assert(8L == count)
       case ("image/jpeg", count) => assert(18L == count)
       case ("text/html", count) => assert(132L == count)
-      case ("text/plain", count) => assert(237L == count)
+      case ("text/plain", count) => assert(86L == count)
       case ("application/xml", count) => assert(1L == count)
       case ("application/rss+xml", count) => assert(9L == count)
       case ("application/xhtml+xml", count) => assert(1L == count)
-      case ("application/octet-stream", count) => assert(63L == count)
+      case ("application/octet-stream", count) => assert(26L == count)
       case ("application/x-shockwave-flash", count) => assert(8L == count)
       case (_, count) => print(_)
     }

--- a/src/test/scala/io/archivesunleashed/app/PlainTextExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/PlainTextExtractorTest.scala
@@ -49,25 +49,13 @@ class PlainTextExtractorTest extends FunSuite with BeforeAndAfter {
     assert(rddResults(0)._1 == "20080430")
     assert(rddResults(0)._2 == "www.archive.org")
     assert(rddResults(0)._3 == "http://www.archive.org/")
-    assert(rddResults(0)._4 == "HTTP/1.1 200 OK Date: " +
-      "Wed, 30 Apr 2008 20:48:25 GMT Server: Apache/2.0.54 (Ubuntu) " +
-      "PHP/5.0.5-2ubuntu1.4 mod_ssl/2.0.54 OpenSSL/0.9.7g Last-Modified: " +
-      "Wed, 09 Jan 2008 23:18:29 GMT ETag: \"47ac-16e-4f9e5b40\" " +
-      "Accept-Ranges: bytes Content-Length: 366 Connection: " +
-      "close Content-Type: text/html; charset=UTF-8 Please visit " +
-      "our website at: http://www.archive.org")
+    assert(rddResults(0)._4 == "Please visit our website at: http://www.archive.org")
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20080430")
     assert(dfResults(0).get(1) == "www.archive.org")
     assert(dfResults(0).get(2) == "http://www.archive.org/")
-    assert(dfResults(0).get(3) == "HTTP/1.1 200 OK Date: " +
-      "Wed, 30 Apr 2008 20:48:25 GMT Server: Apache/2.0.54 (Ubuntu) " +
-      "PHP/5.0.5-2ubuntu1.4 mod_ssl/2.0.54 OpenSSL/0.9.7g Last-Modified: " +
-      "Wed, 09 Jan 2008 23:18:29 GMT ETag: \"47ac-16e-4f9e5b40\" " +
-      "Accept-Ranges: bytes Content-Length: 366 Connection: " +
-      "close Content-Type: text/html; charset=UTF-8 Please visit " +
-      "our website at: http://www.archive.org")
+    assert(dfResults(0).get(3) == "Please visit our website at: http://www.archive.org")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/df/SimpleDfTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/SimpleDfTest.scala
@@ -51,7 +51,7 @@ class SimpleDfTest extends FunSuite with BeforeAndAfter {
     import spark.implicits._
     // scalastyle:on
 
-    val results = df.select(ExtractBaseDomain($"Url").as("Domain"))
+    val results = df.select(ExtractDomain($"Url").as("Domain"))
       .groupBy("Domain").count().orderBy(desc("count")).head(3)
 
     // Results should be:


### PR DESCRIPTION
Addresses #367 #368 #369 

This works:

```
import io.archivesunleashed._
import io.archivesunleashed.df._

RecordLoader.loadArchives("src/test/resources/warc/example.warc.gz", sc).extractValidPagesDF()
  .select($"url")
  .show(20, false)

RecordLoader.loadArchives("src/test/resources/warc/example.warc.gz", sc).extractValidPagesDF()
  .select(ExtractDomain($"url"))
  .show(20, false)

RecordLoader.loadArchives("src/test/resources/warc/example.warc.gz", sc).extractValidPagesDF()
  .select(RemovePrefixWWW(ExtractDomain($"url")))
  .show(20, false)

val pages = RecordLoader.loadArchives("src/test/resources/warc/example.warc.gz", sc).extractValidPagesDF()
  .select(RemoveHttpHeader($"content"))
  .head(10)

pages(1).getString(0)
// HTML, no header

val pages = RecordLoader.loadArchives("src/test/resources/warc/example.warc.gz", sc).extractValidPagesDF()
  .select(RemoveHTML($"content"))
  .head(10)

pages(1).getString(0)
// Plain text, no header
```

I will adjust camel casing issues based on outcome of discussion in #368 