### PR TITLE
Add additional filters for fextFiles; resolves #362.

### DIFF
--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -538,7 +538,7 @@ package object archivesunleashed {
     def textFiles(): DataFrame = {
       val records = rdd
         .keepMimeTypes(Set("text/plain"))
-        .filter(r => r.getMimeType.endsWith("text/plain")
+        .filter(r => r.getMimeType == "text/plain"
           && (!r.getUrl.toLowerCase.endsWith("robots.txt")
             && !r.getUrl.toLowerCase.endsWith(".js")
             && !r.getUrl.toLowerCase.endsWith(".css")

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -543,7 +543,9 @@ package object archivesunleashed {
             && !r.getUrl.toLowerCase.endsWith(".js")
             && !r.getUrl.toLowerCase.endsWith(".css")
             && !r.getUrl.toLowerCase.endsWith(".htm")
-            && !r.getUrl.toLowerCase.endsWith(".html"))
+            && !r.getUrl.toLowerCase.endsWith(".html")
+            && !r.getUrl.toLowerCase.startsWith("dns:")
+            && !r.getUrl.toLowerCase.startsWith("filedesc:"))
         )
         .map(r => {
           val bytes = r.getBinaryBytes

--- a/src/test/scala/io/archivesunleashed/df/ExtractTextFilesDetailsTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractTextFilesDetailsTest.scala
@@ -28,6 +28,7 @@ import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 class TextFilesTest extends FunSuite with BeforeAndAfter with Matchers {
   private val warcPath = Resources.getResource("warc/example.txt.warc.gz").getPath
   private val testPath = Resources.getResource("warc/example.warc.gz").getPath
+  private val filedescPath = Resources.getResource("arc/example.arc.gz").getPath
   private val master = "local[4]"
   private val appName = "example-df"
   private var sc: SparkContext = _
@@ -72,6 +73,18 @@ class TextFilesTest extends FunSuite with BeforeAndAfter with Matchers {
     robots(1)(0).toString should not include (".htm")
     robots(0)(0).toString should not include (".html")
     robots(1)(0).toString should not include (".html")
+  }
+
+  test("Text Files DF dns or filedesc") {
+    val df = RecordLoader.loadArchives(filedescPath, sc)
+      .textFiles()
+
+    val issue362 = df.select("url").head(50).toList
+
+    issue362(0)(0).toString should not include ("filedesc://")
+    issue362(1)(0).toString should not include ("filedesc://")
+    issue362(0)(0).toString should not include ("dns:")
+    issue362(1)(0).toString should not include ("dns:")
   }
 
   after {


### PR DESCRIPTION
**GitHub issue(s)**:

- #362

# What does this Pull Request do?

Add additional filters for fextFiles; resolves #362.

- Add filedesc, and dns filter (arc files)
- Add test case

You can see `filedesc` and `dns` in the ARC test fixtures:

```scala

import io.archivesunleashed._
import io.archivesunleashed.df._

val df = RecordLoader.loadArchives("/home/nruest/Projects/au/aut/src/test/resources/arc/*gz",sc)
df.all().select("url").show(5, false)
```

```
+-------------------------------------------------+
|url                                              |
+-------------------------------------------------+
|filedesc://IAH-20080430204825-00000-blackbook.arc|
|dns:www.archive.org                              |
|http://www.archive.org/robots.txt                |
|http://www.archive.org/                          |
|http://www.archive.org/index.php                 |
+-------------------------------------------------+
only showing top 5 rows
```

# How should this be tested?

The updated test catches the above examples examples.

I'm doing a more robust test on the BANQ collection in question on #362 now. I'll move this out of draft if it is successful.
