### PR TITLE
Use https for maven repo.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
   <repositories>
     <repository>
       <id>maven</id>
-      <url>http://repo.maven.apache.org/maven2/</url>
+      <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
       <id>mvn-repo</id>


### PR DESCRIPTION
**GitHub issue(s)**: none

# What does this Pull Request do?
- Looks like repos are forcing https to be used now:
[WARNING] repository metadata for: 'artifact joda-time:joda-time' could not be retrieved from repository: maven due to an error: Failed to transfer file: http://repo.maven.apache.org/maven2/joda-time/joda-time/maven-metadata.xml. Return code is: 501 , ReasonPhrase:HTTPS Required.

# How should this be tested?

TravisCI