### PR TITLE
Remaining Matchbox implementations for Scala

### DIFF
--- a/src/main/scala/io/archivesunleashed/app/ExtractImageDetailsDF.scala
+++ b/src/main/scala/io/archivesunleashed/app/ExtractImageDetailsDF.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 The Archives Unleashed Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.archivesunleashed.app
+
+import io.archivesunleashed._
+import io.archivesunleashed.{DataFrameLoader}
+import org.apache.commons.io.FilenameUtils
+import io.archivesunleashed.df.{ComputeImageSizeDF, ComputeMD5DF, ComputeSHA1DF, GetExtensionMimeDF}
+import org.apache.hadoop.fs.{Path}
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.functions.udf
+import java.net.URL
+import java.util.Base64
+
+/** Extracts image details given raw bytes. */
+object ExtractImageDetailsDF {
+
+  /** Extract Image details from web archive using Data Frame and Spark SQL.
+    *
+    * @param d Data frame obtained from RecordLoader
+    * @return Dataset[Row], where the schema is (crawl_date, url, filename, extension, mime_type_server, mime_type_tika, width, height, MD5, SHA1, body)
+    */
+  def apply(d: DataFrame): Dataset[Row] = {
+    val spark = SparkSession.builder().master("local").getOrCreate()
+    // scalastyle:off
+    import spark.implicits._
+    // scalastyle:on
+
+    val width = udf((size: Any) => size.toString.split(",")(0).drop(1))
+    val height = udf((size: Any) => size.toString.split(",")(1).dropRight(1))
+    val body = udf((bytes: Array[Byte]) => Base64.getEncoder.encodeToString(bytes))
+    val filename = udf((url: String) => FilenameUtils.getName(new URL(url).getPath()))
+    val urlClass = udf((url: String) => new URL(url).getPath())
+
+    d.select(  $"crawl_date",
+               $"url", 
+               filename($"url").as("filename"),
+               GetExtensionMimeDF(urlClass($"url") ,$"mime_type_tika").as("extension"),
+               $"mime_type_web_server",
+               $"mime_type_tika",
+               width(ComputeImageSizeDF($"bytes")).as("width"), 
+               height(ComputeImageSizeDF($"bytes")).as("height"),
+               ComputeMD5DF($"bytes").as("MD5"),
+               ComputeSHA1DF($"bytes").as("SHA1"),
+               body($"bytes").as("body")
+            )
+
+  }
+}

--- a/src/test/scala/io/archivesunleashed/app/ExtarctImageDetailsDFTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/ExtarctImageDetailsDFTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 The Archives Unleashed Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.archivesunleashed.app
+
+import com.google.common.io.Resources
+import io.archivesunleashed.RecordLoader
+import org.apache.spark.{SparkConf, SparkContext}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfter, FunSuite}
+
+@RunWith(classOf[JUnitRunner])
+class ExtractImageDetailsDFTest extends FunSuite with BeforeAndAfter {
+  private val arcPath = Resources.getResource("arc/example.arc.gz").getPath
+  private var sc: SparkContext = _
+  private val master = "local[4]"
+  private val appName = "example-spark"
+
+  before {
+    val conf = new SparkConf()
+    .setMaster(master)
+    .setAppName(appName)
+    conf.set("spark.driver.allowMultipleContexts", "true");
+    sc = new SparkContext(conf)
+  }
+
+  test("extracts Image Details") {
+    val exampledf = RecordLoader.loadArchives(arcPath, sc).keepImages().all()
+    val imageDetails = ExtractImageDetailsDF(exampledf)
+    val response1 = "http://www.archive.org/images/logoc.jpg"
+    val response2 = "logoc.jpg"
+    assert (imageDetails.take(1)(0)(1).toString == response1)
+    assert (imageDetails.take(1)(0)(2).toString == response2)
+  }
+  after {
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+}


### PR DESCRIPTION
Remaining Matchbox implementations for Scala

#223 

For Testing

ExtractImageDetailsDF
```Scala
import io.archivesunleashed._
import io.archivesunleashed.app._

val df = RecordLoader.loadArchives("./src/test/resources/arc/example.arc.gz",sc)
					 .keepImages()
					 .all()

ExtractImageDetailsDF(df).show(10)
```