### PR TITLE
Restyle UDFs in the context of DataFrames

### DIFF
--- a/src/main/scala/io/archivesunleashed/df/package.scala
+++ b/src/main/scala/io/archivesunleashed/df/package.scala
@@ -22,6 +22,7 @@ import java.util.Base64
 import org.apache.commons.io.IOUtils
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.udf
+import scala.util.matching.Regex
 
 /**
   * UDFs for data frames.
@@ -59,7 +60,33 @@ package object df {
 
   val DetectMimeTypeTikaDF = udf((io.archivesunleashed.matchbox.DetectMimeTypeTika.apply(_: Array[Byte])))
 
-  val discardHttpStatusDF = udf((statusCode: String, statusCodes: Seq[String]) => !statusCodes.contains(statusCode))
+  val hasHttpStatusDF = udf((statusCode: String, statusCodes: Seq[String]) => statusCodes.contains(statusCode))
+
+  val hasMimeTypesDF = udf((mimeType: String, mimeTypes: Seq[String]) => mimeTypes.contains(mimeType))
+
+  val hasDateDF = udf((date_ : String, date: String) => date_ == date)
+
+  val hasUrlsDF = udf((url: String, urls: Seq[String]) => urls.contains(url))
+
+  val hasDomainsDF = udf((domain: String, domains: Seq[String]) => domains.contains(domain))
+
+  val hasContentDF = udf((c: String, contentREs: Seq[String]) => {
+                          contentREs.map(re =>
+                          (re.r findFirstIn c) match {
+                            case Some(v) => true
+                            case None => false
+                          }).exists(identity)
+                        })
+
+  val hasUrlPatternsDF = udf((urlPattern: String, urlREs: Seq[String]) => {
+                              urlREs.map(re =>
+                                urlPattern match {
+                                  case re.r() => true
+                                  case _ => false
+                              }).exists(identity)
+                            })
+
+  val hasLanguagesDF = udf((language: String, languages: Seq[String]) => languages.contains(language))
 
   /**
    * Given a dataframe, serializes binary object and saves to disk

--- a/src/main/scala/io/archivesunleashed/df/package.scala
+++ b/src/main/scala/io/archivesunleashed/df/package.scala
@@ -60,17 +60,17 @@ package object df {
 
   val DetectMimeTypeTikaDF = udf((io.archivesunleashed.matchbox.DetectMimeTypeTika.apply(_: Array[Byte])))
 
-  val hasHttpStatusDF = udf((statusCode: String, statusCodes: Seq[String]) => statusCodes.contains(statusCode))
+  val hasHttpStatus = udf((statusCode: String, statusCodes: Seq[String]) => statusCodes.contains(statusCode))
 
-  val hasMimeTypesDF = udf((mimeType: String, mimeTypes: Seq[String]) => mimeTypes.contains(mimeType))
+  val hasMimeTypes = udf((mimeType: String, mimeTypes: Seq[String]) => mimeTypes.contains(mimeType))
 
-  val hasDateDF = udf((date_ : String, date: String) => date_ == date)
+  val hasDate = udf((date_ : String, date: String) => date_ == date)
 
-  val hasUrlsDF = udf((url: String, urls: Seq[String]) => urls.contains(url))
+  val hasUrls = udf((url: String, urls: Seq[String]) => urls.contains(url))
 
-  val hasDomainsDF = udf((domain: String, domains: Seq[String]) => domains.contains(domain))
+  val hasDomains = udf((domain: String, domains: Seq[String]) => domains.contains(domain))
 
-  val hasContentDF = udf((c: String, contentREs: Seq[String]) => {
+  val hasContent = udf((c: String, contentREs: Seq[String]) => {
                           contentREs.map(re =>
                           (re.r findFirstIn c) match {
                             case Some(v) => true
@@ -78,7 +78,7 @@ package object df {
                           }).exists(identity)
                         })
 
-  val hasUrlPatternsDF = udf((urlPattern: String, urlREs: Seq[String]) => {
+  val hasUrlPatterns = udf((urlPattern: String, urlREs: Seq[String]) => {
                               urlREs.map(re =>
                                 urlPattern match {
                                   case re.r() => true
@@ -86,7 +86,7 @@ package object df {
                               }).exists(identity)
                             })
 
-  val hasLanguagesDF = udf((language: String, languages: Seq[String]) => languages.contains(language))
+  val hasLanguages = udf((language: String, languages: Seq[String]) => languages.contains(language))
 
   /**
    * Given a dataframe, serializes binary object and saves to disk

--- a/src/main/scala/io/archivesunleashed/df/package.scala
+++ b/src/main/scala/io/archivesunleashed/df/package.scala
@@ -59,6 +59,8 @@ package object df {
 
   val DetectMimeTypeTikaDF = udf((io.archivesunleashed.matchbox.DetectMimeTypeTika.apply(_: Array[Byte])))
 
+  val discardHttpStatusDF = udf((statusCode: String, statusCodes: Seq[String]) => !statusCodes.contains(statusCode))
+
   /**
    * Given a dataframe, serializes binary object and saves to disk
    * @param df the input dataframe

--- a/src/test/scala/io/archivesunleashed/RecordDFTest.scala
+++ b/src/test/scala/io/archivesunleashed/RecordDFTest.scala
@@ -28,26 +28,26 @@ import org.scalatest.{BeforeAndAfter, FunSuite}
 import org.apache.spark.sql.functions.lit
 
 @RunWith(classOf[JUnitRunner])
-class RecordDFTest extends FunSuite with BeforeAndAfter{
+class RecordDFTest extends FunSuite with BeforeAndAfter {
   private val arcPath = Resources.getResource("arc/example.arc.gz").getPath
   private val master = "local[4]"
   private val appName = "example-spark"
   private var sc: SparkContext = _
  
-  before {         
-    val conf = new SparkConf()  
-      .setMaster(master)    
-      .setAppName(appName)   
-    conf.set("spark.driver.allowMultipleContexts", "true");  
-    sc = new SparkContext(conf)   
+  before {
+    val conf = new SparkConf()
+      .setMaster(master)
+      .setAppName(appName)
+    conf.set("spark.driver.allowMultipleContexts", "true");
+    sc = new SparkContext(conf)
   }
 
   test("Keep valid pages DF") {
     val expected = "http://www.archive.org/"
     val base = RecordLoader.loadArchives(arcPath, sc)
-      .all()
-      .keepValidPagesDF()
-      .take(1)(0)(1)
+		.all()
+		.keepValidPagesDF()
+		.take(1)(0)(1)
     assert (base.toString == expected)
   }
 
@@ -59,10 +59,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
 
     val expected = "000"
     val base = RecordLoader.loadArchives(arcPath, sc)
-      .all()
-      .select($"http_status_code")
-      .filter(hasHttpStatus($"http_status_code", lit(Array("200","000"))))
-      .take(1)(0)(0) 
+		.all()
+		.select($"http_status_code")
+		.filter(hasHttpStatus($"http_status_code", lit(Array("200","000"))))
+		.take(1)(0)(0) 
 
     assert (base.toString == expected)
   }
@@ -76,16 +76,16 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
     val expected1 = "http://www.archive.org/robots.txt"
     val expected2 = "http://www.archive.org/"
     val base1 = RecordLoader.loadArchives(arcPath, sc)
-        .all()
-        .select($"url")
-        .filter(hasUrls($"url", lit(Array("http://www.archive.org/","http://www.archive.org/robots.txt"))))
-        .take(1)(0)(0)
+		.all()
+		.select($"url")
+		.filter(hasUrls($"url", lit(Array("http://www.archive.org/","http://www.archive.org/robots.txt"))))
+		.take(1)(0)(0)
 
     val base2 = RecordLoader.loadArchives(arcPath, sc)
-        .all()
-        .select($"url")
-        .filter(hasUrls($"url", lit(Array("http://www.archive.org/"))))
-        .take(1)(0)(0)
+		.all()
+		.select($"url")
+		.filter(hasUrls($"url", lit(Array("http://www.archive.org/"))))
+		.take(1)(0)(0)
 
     assert (base1.toString == expected1)
     assert (base2.toString == expected2)
@@ -99,10 +99,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
 
     val expected = "http://www.archive.org/robots.txt"
     val base1 = RecordLoader.loadArchives(arcPath, sc)
-    	.all()
-    	.select($"url")
-    	.filter(hasDomains(ExtractDomainDF($"url"), lit(Array("www.archive.org"))))
-    	.take(1)(0)(0)
+		.all()
+		.select($"url")
+		.filter(hasDomains(ExtractDomainDF($"url"), lit(Array("www.archive.org"))))
+		.take(1)(0)(0)
 
     assert (base1.toString == expected)
   }
@@ -111,9 +111,9 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
     val expected = "image/jpeg"
     val mimeType = Set("image/jpeg")
     val base = RecordLoader.loadArchives(arcPath, sc)
-    	.all()
-    	.keepMimeTypesTikaDF(mimeType)
-    	.take(1)(0)(2)
+		.all()
+		.keepMimeTypesTikaDF(mimeType)
+		.take(1)(0)(2)
 
     assert (base.toString == expected)
   }
@@ -126,10 +126,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
 
     val expected = "text/html"
     val base = RecordLoader.loadArchives(arcPath, sc)
-   		.all()
-   		.select($"mime_type_web_server")
-   		.filter(hasMimeTypes($"mime_type_web_server", lit(Array("text/html"))))
-   		.take(1)(0)(0)
+		.all()
+		.select($"mime_type_web_server")
+		.filter(hasMimeTypes($"mime_type_web_server", lit(Array("text/html"))))
+		.take(1)(0)(0)
 
     assert (base.toString == expected)
   }
@@ -142,10 +142,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
 
     val expected = "http://www.archive.org/images/logoc.jpg"
     val base = RecordLoader.loadArchives(arcPath, sc)
-       .all()
-       .select($"url",$"content")
-       .filter(hasContent($"content", lit(Array("Content-Length: [0-9]{4}"))))
-       .take(1)(0)(0)
+		.all()
+		.select($"url",$"content")
+		.filter(hasContent($"content", lit(Array("Content-Length: [0-9]{4}"))))
+		.take(1)(0)(0)
 
     assert (base.toString == expected)
   }
@@ -158,7 +158,7 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
 
     val expected1 = "http://www.archive.org/images/go-button-gateway.gif"
     val base1 = RecordLoader.loadArchives(arcPath, sc)
-    	.all()
+		.all()
     	.select($"url")
     	.filter(hasUrlPatterns($"url", lit(Array(".*images.*"))))
     	.take(2)(1)(0)
@@ -201,9 +201,9 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
     assert (base.toString == expected)
   }
 
-  after {  
-    if (sc != null) { 
-      sc.stop() 
-    } 
+  after {
+    if (sc != null) {
+      sc.stop()
+    }
   }
 }

--- a/src/test/scala/io/archivesunleashed/RecordDFTest.scala
+++ b/src/test/scala/io/archivesunleashed/RecordDFTest.scala
@@ -33,7 +33,7 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
   private val master = "local[4]"
   private val appName = "example-spark"
   private var sc: SparkContext = _
- 
+
   before {
     val conf = new SparkConf()
       .setMaster(master)
@@ -45,9 +45,9 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
   test("Keep valid pages DF") {
     val expected = "http://www.archive.org/"
     val base = RecordLoader.loadArchives(arcPath, sc)
-		.all()
-		.keepValidPagesDF()
-		.take(1)(0)(1)
+	  .all()
+	  .keepValidPagesDF()
+	  .take(1)(0)(1)
     assert (base.toString == expected)
   }
 
@@ -59,10 +59,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
 
     val expected = "000"
     val base = RecordLoader.loadArchives(arcPath, sc)
-		.all()
-		.select($"http_status_code")
-		.filter(hasHttpStatus($"http_status_code", lit(Array("200","000"))))
-		.take(1)(0)(0) 
+	  .all()
+	  .select($"http_status_code")
+	  .filter(hasHttpStatus($"http_status_code", lit(Array("200","000"))))
+	  .take(1)(0)(0) 
 
     assert (base.toString == expected)
   }
@@ -76,16 +76,16 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
     val expected1 = "http://www.archive.org/robots.txt"
     val expected2 = "http://www.archive.org/"
     val base1 = RecordLoader.loadArchives(arcPath, sc)
-		.all()
-		.select($"url")
-		.filter(hasUrls($"url", lit(Array("http://www.archive.org/","http://www.archive.org/robots.txt"))))
-		.take(1)(0)(0)
+	  .all()
+	  .select($"url")
+	  .filter(hasUrls($"url", lit(Array("http://www.archive.org/","http://www.archive.org/robots.txt"))))
+	  .take(1)(0)(0)
 
     val base2 = RecordLoader.loadArchives(arcPath, sc)
-		.all()
-		.select($"url")
-		.filter(hasUrls($"url", lit(Array("http://www.archive.org/"))))
-		.take(1)(0)(0)
+	  .all()
+	  .select($"url")
+	  .filter(hasUrls($"url", lit(Array("http://www.archive.org/"))))
+	  .take(1)(0)(0)
 
     assert (base1.toString == expected1)
     assert (base2.toString == expected2)
@@ -99,10 +99,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
 
     val expected = "http://www.archive.org/robots.txt"
     val base1 = RecordLoader.loadArchives(arcPath, sc)
-		.all()
-		.select($"url")
-		.filter(hasDomains(ExtractDomainDF($"url"), lit(Array("www.archive.org"))))
-		.take(1)(0)(0)
+	  .all()
+	  .select($"url")
+	  .filter(hasDomains(ExtractDomainDF($"url"), lit(Array("www.archive.org"))))
+	  .take(1)(0)(0)
 
     assert (base1.toString == expected)
   }
@@ -111,9 +111,9 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
     val expected = "image/jpeg"
     val mimeType = Set("image/jpeg")
     val base = RecordLoader.loadArchives(arcPath, sc)
-		.all()
-		.keepMimeTypesTikaDF(mimeType)
-		.take(1)(0)(2)
+	  .all()
+	  .keepMimeTypesTikaDF(mimeType)
+	  .take(1)(0)(2)
 
     assert (base.toString == expected)
   }
@@ -126,10 +126,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
 
     val expected = "text/html"
     val base = RecordLoader.loadArchives(arcPath, sc)
-		.all()
-		.select($"mime_type_web_server")
-		.filter(hasMimeTypes($"mime_type_web_server", lit(Array("text/html"))))
-		.take(1)(0)(0)
+	  .all()
+	  .select($"mime_type_web_server")
+	  .filter(hasMimeTypes($"mime_type_web_server", lit(Array("text/html"))))
+	  .take(1)(0)(0)
 
     assert (base.toString == expected)
   }
@@ -142,10 +142,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
 
     val expected = "http://www.archive.org/images/logoc.jpg"
     val base = RecordLoader.loadArchives(arcPath, sc)
-		.all()
-		.select($"url",$"content")
-		.filter(hasContent($"content", lit(Array("Content-Length: [0-9]{4}"))))
-		.take(1)(0)(0)
+	  .all()
+	  .select($"url",$"content")
+	  .filter(hasContent($"content", lit(Array("Content-Length: [0-9]{4}"))))
+	  .take(1)(0)(0)
 
     assert (base.toString == expected)
   }
@@ -158,17 +158,17 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
 
     val expected1 = "http://www.archive.org/images/go-button-gateway.gif"
     val base1 = RecordLoader.loadArchives(arcPath, sc)
-		.all()
-		.select($"url")
-		.filter(hasUrlPatterns($"url", lit(Array(".*images.*"))))
-		.take(2)(1)(0)
+	  .all()
+	  .select($"url")
+	  .filter(hasUrlPatterns($"url", lit(Array(".*images.*"))))
+	  .take(2)(1)(0)
 
     val expected2 = "http://www.archive.org/index.php?skin=classic"
     val base2 = RecordLoader.loadArchives(arcPath, sc)
-		.all()
-		.select($"url")
-		.filter(hasUrlPatterns($"url", lit(Array(".*index.*"))))
-		.take(3)(1)(0)
+	  .all()
+	  .select($"url")
+	  .filter(hasUrlPatterns($"url", lit(Array(".*index.*"))))
+	  .take(3)(1)(0)
 
     assert (base1.toString == expected1)
     assert (base2.toString == expected2)
@@ -182,10 +182,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
 
     val expected = "de"
     val base = RecordLoader.loadArchives(arcPath, sc)
-		.all()
-		.select(DetectLanguageDF(RemoveHTMLDF($"content")).as("language"))
-		.filter(hasLanguages(DetectLanguageDF(RemoveHTMLDF($"content")), lit(Array("de","ht"))))
-		.take(1)(0)(0)
+	  .all()
+	  .select(DetectLanguageDF(RemoveHTMLDF($"content")).as("language"))
+	  .filter(hasLanguages(DetectLanguageDF(RemoveHTMLDF($"content")), lit(Array("de","ht"))))
+	  .take(1)(0)(0)
 
     assert (base.toString == expected)
   }

--- a/src/test/scala/io/archivesunleashed/RecordDFTest.scala
+++ b/src/test/scala/io/archivesunleashed/RecordDFTest.scala
@@ -159,9 +159,9 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
     val expected1 = "http://www.archive.org/images/go-button-gateway.gif"
     val base1 = RecordLoader.loadArchives(arcPath, sc)
 		.all()
-    	.select($"url")
-    	.filter(hasUrlPatterns($"url", lit(Array(".*images.*"))))
-    	.take(2)(1)(0)
+		.select($"url")
+		.filter(hasUrlPatterns($"url", lit(Array(".*images.*"))))
+		.take(2)(1)(0)
 
     val expected2 = "http://www.archive.org/index.php?skin=classic"
     val base2 = RecordLoader.loadArchives(arcPath, sc)

--- a/src/test/scala/io/archivesunleashed/RecordDFTest.scala
+++ b/src/test/scala/io/archivesunleashed/RecordDFTest.scala
@@ -165,10 +165,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
 
     val expected2 = "http://www.archive.org/index.php?skin=classic"
     val base2 = RecordLoader.loadArchives(arcPath, sc)
-    	.all()
-    	.select($"url")
-    	.filter(hasUrlPatterns($"url", lit(Array(".*index.*"))))
-    	.take(3)(1)(0)
+		.all()
+		.select($"url")
+		.filter(hasUrlPatterns($"url", lit(Array(".*index.*"))))
+		.take(3)(1)(0)
 
     assert (base1.toString == expected1)
     assert (base2.toString == expected2)
@@ -182,10 +182,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
 
     val expected = "de"
     val base = RecordLoader.loadArchives(arcPath, sc)
-       .all()
-       .select(DetectLanguageDF(RemoveHTMLDF($"content")).as("language"))
-       .filter(hasLanguages(DetectLanguageDF(RemoveHTMLDF($"content")), lit(Array("de","ht"))))
-       .take(1)(0)(0)
+		.all()
+		.select(DetectLanguageDF(RemoveHTMLDF($"content")).as("language"))
+		.filter(hasLanguages(DetectLanguageDF(RemoveHTMLDF($"content")), lit(Array("de","ht"))))
+		.take(1)(0)(0)
 
     assert (base.toString == expected)
   }

--- a/src/test/scala/io/archivesunleashed/RecordDFTest.scala
+++ b/src/test/scala/io/archivesunleashed/RecordDFTest.scala
@@ -76,16 +76,16 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
     val expected1 = "http://www.archive.org/robots.txt"
     val expected2 = "http://www.archive.org/"
     val base1 = RecordLoader.loadArchives(arcPath, sc)
-                            .all()
-                            .select($"url")
-                            .filter(hasUrls($"url", lit(Array("http://www.archive.org/","http://www.archive.org/robots.txt"))))
-                            .take(1)(0)(0)
+        .all()
+        .select($"url")
+        .filter(hasUrls($"url", lit(Array("http://www.archive.org/","http://www.archive.org/robots.txt"))))
+        .take(1)(0)(0)
 
     val base2 = RecordLoader.loadArchives(arcPath, sc)
-                            .all()
-                            .select($"url")
-                            .filter(hasUrls($"url", lit(Array("http://www.archive.org/"))))
-                            .take(1)(0)(0)
+        .all()
+        .select($"url")
+        .filter(hasUrls($"url", lit(Array("http://www.archive.org/"))))
+        .take(1)(0)(0)
 
     assert (base1.toString == expected1)
     assert (base2.toString == expected2)
@@ -99,10 +99,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
 
     val expected = "http://www.archive.org/robots.txt"
     val base1 = RecordLoader.loadArchives(arcPath, sc)
-                            .all()
-                            .select($"url")
-                            .filter(hasDomains(ExtractDomainDF($"url"), lit(Array("www.archive.org"))))
-                            .take(1)(0)(0)
+    	.all()
+    	.select($"url")
+    	.filter(hasDomains(ExtractDomainDF($"url"), lit(Array("www.archive.org"))))
+    	.take(1)(0)(0)
 
     assert (base1.toString == expected)
   }
@@ -111,9 +111,9 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
     val expected = "image/jpeg"
     val mimeType = Set("image/jpeg")
     val base = RecordLoader.loadArchives(arcPath, sc)
-                           .all()
-                           .keepMimeTypesTikaDF(mimeType)
-                           .take(1)(0)(2)
+    	.all()
+    	.keepMimeTypesTikaDF(mimeType)
+    	.take(1)(0)(2)
 
     assert (base.toString == expected)
   }
@@ -126,10 +126,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
 
     val expected = "text/html"
     val base = RecordLoader.loadArchives(arcPath, sc)
-                           .all()
-                           .select($"mime_type_web_server")
-                           .filter(hasMimeTypes($"mime_type_web_server", lit(Array("text/html"))))
-                           .take(1)(0)(0)
+   		.all()
+   		.select($"mime_type_web_server")
+   		.filter(hasMimeTypes($"mime_type_web_server", lit(Array("text/html"))))
+   		.take(1)(0)(0)
 
     assert (base.toString == expected)
   }
@@ -142,10 +142,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
 
     val expected = "http://www.archive.org/images/logoc.jpg"
     val base = RecordLoader.loadArchives(arcPath, sc)
-                           .all()
-                           .select($"url",$"content")
-                           .filter(hasContent($"content", lit(Array("Content-Length: [0-9]{4}"))))
-                           .take(1)(0)(0)
+       .all()
+       .select($"url",$"content")
+       .filter(hasContent($"content", lit(Array("Content-Length: [0-9]{4}"))))
+       .take(1)(0)(0)
 
     assert (base.toString == expected)
   }
@@ -158,17 +158,17 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
 
     val expected1 = "http://www.archive.org/images/go-button-gateway.gif"
     val base1 = RecordLoader.loadArchives(arcPath, sc)
-                            .all()
-                            .select($"url")
-                            .filter(hasUrlPatterns($"url", lit(Array(".*images.*"))))
-                            .take(2)(1)(0)
+    	.all()
+    	.select($"url")
+    	.filter(hasUrlPatterns($"url", lit(Array(".*images.*"))))
+    	.take(2)(1)(0)
 
     val expected2 = "http://www.archive.org/index.php?skin=classic"
     val base2 = RecordLoader.loadArchives(arcPath, sc)
-                            .all()
-                            .select($"url")
-                            .filter(hasUrlPatterns($"url", lit(Array(".*index.*"))))
-                            .take(3)(1)(0)
+    	.all()
+    	.select($"url")
+    	.filter(hasUrlPatterns($"url", lit(Array(".*index.*"))))
+    	.take(3)(1)(0)
 
     assert (base1.toString == expected1)
     assert (base2.toString == expected2)
@@ -182,10 +182,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter{
 
     val expected = "de"
     val base = RecordLoader.loadArchives(arcPath, sc)
-                           .all()
-                           .select(DetectLanguageDF(RemoveHTMLDF($"content")).as("language"))
-                           .filter(hasLanguages(DetectLanguageDF(RemoveHTMLDF($"content")), lit(Array("de","ht"))))
-                           .take(1)(0)(0)
+       .all()
+       .select(DetectLanguageDF(RemoveHTMLDF($"content")).as("language"))
+       .filter(hasLanguages(DetectLanguageDF(RemoveHTMLDF($"content")), lit(Array("de","ht"))))
+       .take(1)(0)(0)
 
     assert (base.toString == expected)
   }


### PR DESCRIPTION
Restyle UDFs in the context of DataFrames.

#425 

```scala
import org.apache.spark.sql.functions.lit
import io.archivesunleashed._
import io.archivesunleashed.df._

RecordLoader.loadArchives("./src/test/resources/arc/example.arc.gz",sc)
			.all()
			.select($"url",$"http_status_code")
			.filter(hasHttpStatus($"http_status_code", lit(Array("200","000"))))
			.show(10,false)

import org.apache.spark.sql.functions.lit
import io.archivesunleashed._
import io.archivesunleashed.df._

RecordLoader.loadArchives("./src/test/resources/arc/example.arc.gz",sc)
			.all()
			.select($"content")
			.filter(hasContent($"content", lit(Array("Content-Length: [0-9]{4}"))))
			.show(3,false)

import org.apache.spark.sql.functions.lit
import io.archivesunleashed._
import io.archivesunleashed.df._

RecordLoader.loadArchives("./src/test/resources/arc/example.arc.gz",sc)
			.all()
			.select($"url")
			.filter(hasUrlPatterns($"url", lit(Array(".*images.*"))))
			.show(10,false)

import org.apache.spark.sql.functions.lit
import io.archivesunleashed._
import io.archivesunleashed.df._

RecordLoader.loadArchives("./src/test/resources/arc/example.arc.gz",sc)
			.all()
			.select(DetectLanguageDF(RemoveHTMLDF($"content")).as("language"))
			.filter(hasLanguages(DetectLanguageDF(RemoveHTMLDF($"content")), lit(Array("de","ht"))))
			.show(10,false)

import org.apache.spark.sql.functions.lit
import io.archivesunleashed._
import io.archivesunleashed.df._

RecordLoader.loadArchives("./src/test/resources/arc/example.arc.gz",sc)
			.all()
			.select($"mime_type_web_server")
			.filter(hasMimeTypes($"mime_type_web_server", lit(Array("text/html"))))
			.show(10,false)

import org.apache.spark.sql.functions.lit
import io.archivesunleashed._
import io.archivesunleashed.df._

RecordLoader.loadArchives("./src/test/resources/arc/example.arc.gz",sc)
			.all()
			.select($"url")
			.filter(hasUrls($"url", lit(Array("http://www.archive.org/","http://www.archive.org/robots.txt"))))
			.show(10,false)

import org.apache.spark.sql.functions.lit
import io.archivesunleashed._
import io.archivesunleashed.df._

RecordLoader.loadArchives("./src/test/resources/arc/example.arc.gz",sc)
			.all()
			.select($"url")
			.filter(hasDomains(ExtractDomainDF($"url"), lit(Array("www.archive.org"))))
			.show(10,false)
```