### PR TITLE
Update PlainTextExtractor to output a single column; text.

### DIFF
--- a/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
@@ -32,6 +32,6 @@ object PlainTextExtractor {
     // scalastyle:off
     import spark.implicits._
     // scalastyle:on
-    d.select(ExtractBoilerpipeTextDF(RemoveHTMLDF($"content")).as("content"))
+    d.select(ExtractBoilerpipeTextDF($"content").as("content"))
   }
 }

--- a/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
@@ -17,8 +17,7 @@
 package io.archivesunleashed.app
 
 import io.archivesunleashed.ArchiveRecord
-import io.archivesunleashed.df.{ExtractBoilerpipeTextDF, RemoveHTMLDF,
-                                RemoveHTTPHeaderDF}
+import io.archivesunleashed.df.{ExtractBoilerpipeTextDF}
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 
 object PlainTextExtractor {

--- a/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
@@ -17,7 +17,7 @@
 package io.archivesunleashed.app
 
 import io.archivesunleashed.ArchiveRecord
-import io.archivesunleashed.df.{ExtractDomainDF, RemoveHTMLDF,
+import io.archivesunleashed.df.{ExtractBoilerpipeTextDF, RemoveHTMLDF,
                                 RemoveHTTPHeaderDF}
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 
@@ -32,7 +32,6 @@ object PlainTextExtractor {
     // scalastyle:off
     import spark.implicits._
     // scalastyle:on
-    d.select($"crawl_date", ExtractDomainDF($"url").as("domain"),
-      $"url", RemoveHTMLDF(RemoveHTTPHeaderDF($"content")).as("text"))
+    d.select(ExtractBoilerpipeTextDF(RemoveHTMLDF($"content")).as("content"))
   }
 }

--- a/src/test/scala/io/archivesunleashed/app/PlainTextExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/PlainTextExtractorTest.scala
@@ -45,10 +45,12 @@ class PlainTextExtractorTest extends FunSuite with BeforeAndAfter {
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "")
-    assert(dfResults(34).get(0)
+    assert(dfResults(4).get(0)
       .toString
-        .startsWith("Internet Archive Frequently Asked Questions Web | "))
-    assert(dfResults(50).get(0) == "")
+      .startsWith("Author: Spivak, John L. (John Louis), b. 1897 Published: 1939"))
+    assert(dfResults(50).get(0)
+      .toString
+      .startsWith("How many hours in a day They tell me 24 "))
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/PlainTextExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/PlainTextExtractorTest.scala
@@ -38,16 +38,17 @@ class PlainTextExtractorTest extends FunSuite with BeforeAndAfter {
     sc = new SparkContext(conf)
   }
 
-  test("Plain text extractor RDD & DF") {
+  test("Plain text extractor") {
     val df = RecordLoader.loadArchives(arcPath, sc).webpages()
     val dfResults = PlainTextExtractor(df).collect()
     val RESULTSLENGTH = 94
 
     assert(dfResults.length == RESULTSLENGTH)
-    assert(dfResults(0).get(0) == "20080430")
-    assert(dfResults(0).get(1) == "www.archive.org")
-    assert(dfResults(0).get(2) == "http://www.archive.org/")
-    assert(dfResults(0).get(3) == "Please visit our website at: http://www.archive.org")
+    assert(dfResults(0).get(0) == "")
+    assert(dfResults(34).get(0)
+      .toString
+        .startsWith("Internet Archive Frequently Asked Questions Web | "))
+    assert(dfResults(50).get(0) == "")
   }
 
   after {


### PR DESCRIPTION
**GitHub issue(s)**: #452 

# What does this Pull Request do?

Update PlainTextExtractor to output a single column; text.

- Resolves #452
- PlainTextExtractor runs RemoveHTML, and ExtractBoilerplate on
`content`
- Update test

# How should this be tested?

- TravisCI

```shell
bin/spark-submit --class io.archivesunleashed.app.CommandLineAppRunner /home/nruest/Projects/au/aut/target/aut-0.60.1-SNAPSHOT-fatjar.jar --extractor PlainTextExtractor --input /home/nruest/Projects/au/sample-data/geocities/* --output /home/nruest/Projects/au/sample-data/452-test/plaintext
```