### PR TITLE
Move Python UDF methods out of their own class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.archivesunleashed/aut/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.archivesunleashed/aut)
 [![Javadoc](https://javadoc-badge.appspot.com/io.archivesunleashed/aut.svg?label=javadoc)](http://api.docs.archivesunleashed.io/0.70.0/apidocs/index.html)
 [![Scaladoc](https://javadoc-badge.appspot.com/io.archivesunleashed/aut.svg?label=scaladoc)](http://api.docs.archivesunleashed.io/0.70.0/scaladocs/index.html)
-[![UserDocs](https://img.shields.io/badge/UserDocs-0.70.0-green?style=flat)](https://github.com/archivesunleashed/aut-docs/tree/master/aut-0.70.0#the-archives-unleashed-toolkit-latest-documentation)
+[![UserDocs](https://img.shields.io/badge/UserDocs-0.70.0-brightgreen?style=flat)](https://github.com/archivesunleashed/aut-docs/tree/master/aut-0.70.0#the-archives-unleashed-toolkit-latest-documentation)
 [![LICENSE](https://img.shields.io/badge/license-Apache-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 

--- a/src/main/python/aut/__init__.py
+++ b/src/main/python/aut/__init__.py
@@ -1,5 +1,39 @@
 from aut.app import Extract_Popular_Images, Write_Gexf, Write_Graphml
 from aut.common import WebArchive
-from aut.udfs import Udf
+from aut.udfs import (
+    compute_image_size,
+    compute_md5,
+    compute_sha1,
+    detect_language,
+    detect_mime_type_tika,
+    extract_boilerplate,
+    extract_date,
+    extract_domain,
+    extract_image_links,
+    extract_links,
+    get_extension_mime,
+    remove_html,
+    remove_http_header,
+    remove_prefix_www,
+)
 
-__all__ = ["Extract_Popular_Images", "Udf", "WebArchive", "Write_Gexf", "Write_Graphml"]
+__all__ = [
+    "Extract_Popular_Images",
+    "WebArchive",
+    "Write_Gexf",
+    "Write_Graphml",
+    "compute_image_size",
+    "compute_md5",
+    "compute_sha1",
+    "detect_language",
+    "detect_mime_type_tika",
+    "extract_boilerplate",
+    "extract_date",
+    "extract_domain",
+    "extract_image_links",
+    "extract_links",
+    "get_extension_mime",
+    "remove_http_header",
+    "remove_html",
+    "remove_prefix_www",
+]

--- a/src/main/python/aut/udfs.py
+++ b/src/main/python/aut/udfs.py
@@ -3,115 +3,105 @@ from pyspark.sql.column import Column, _to_java_column, _to_seq
 from pyspark.sql.functions import col
 
 
-class Udf:
-    def compute_image_size(col):
-        sc = SparkContext.getOrCreate()
-        udf = (
-            sc.getOrCreate()
-            ._jvm.io.archivesunleashed.udfs.package.computeImageSize()
-            .apply
-        )
-        return Column(udf(_to_seq(sc, [col], _to_java_column)))
+def compute_image_size(col):
+    sc = SparkContext.getOrCreate()
+    udf = (
+        sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.computeImageSize().apply
+    )
+    return Column(udf(_to_seq(sc, [col], _to_java_column)))
 
-    def compute_md5(col):
-        sc = SparkContext.getOrCreate()
-        udf = sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.computeMD5().apply
-        return Column(udf(_to_seq(sc, [col], _to_java_column)))
 
-    def compute_sha1(col):
-        sc = SparkContext.getOrCreate()
-        udf = (
-            sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.computeSHA1().apply
-        )
-        return Column(udf(_to_seq(sc, [col], _to_java_column)))
+def compute_md5(col):
+    sc = SparkContext.getOrCreate()
+    udf = sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.computeMD5().apply
+    return Column(udf(_to_seq(sc, [col], _to_java_column)))
 
-    def detect_language(col):
-        sc = SparkContext.getOrCreate()
-        udf = (
-            sc.getOrCreate()
-            ._jvm.io.archivesunleashed.udfs.package.detectLanguage()
-            .apply
-        )
-        return Column(udf(_to_seq(sc, [col], _to_java_column)))
 
-    def detect_mime_type_tika(col):
-        sc = SparkContext.getOrCreate()
-        udf = (
-            sc.getOrCreate()
-            ._jvm.io.archivesunleashed.udfs.package.detectMimeTypeTika()
-            .apply
-        )
-        return Column(udf(_to_seq(sc, [col], _to_java_column)))
+def compute_sha1(col):
+    sc = SparkContext.getOrCreate()
+    udf = sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.computeSHA1().apply
+    return Column(udf(_to_seq(sc, [col], _to_java_column)))
 
-    def extract_boilerplate(col):
-        sc = SparkContext.getOrCreate()
-        udf = (
-            sc.getOrCreate()
-            ._jvm.io.archivesunleashed.udfs.package.extractBoilerpipeText()
-            .apply
-        )
-        return Column(udf(_to_seq(sc, [col], _to_java_column)))
 
-    def extract_date(col, dates):
-        sc = SparkContext.getOrCreate()
-        udf = (
-            sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.extractDate().apply
-        )
-        return Column(udf(_to_seq(sc, [col], _to_java_column)))
+def detect_language(col):
+    sc = SparkContext.getOrCreate()
+    udf = sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.detectLanguage().apply
+    return Column(udf(_to_seq(sc, [col], _to_java_column)))
 
-    def extract_domain(col):
-        sc = SparkContext.getOrCreate()
-        udf = (
-            sc.getOrCreate()
-            ._jvm.io.archivesunleashed.udfs.package.extractDomain()
-            .apply
-        )
-        return Column(udf(_to_seq(sc, [col], _to_java_column)))
 
-    def extract_image_links(col, image_links):
-        sc = SparkContext.getOrCreate()
-        udf = (
-            sc.getOrCreate()
-            ._jvm.io.archivesunleashed.udfs.package.extractImageLinks()
-            .apply
-        )
-        return Column(udf(_to_seq(sc, [col, image_links], _to_java_column)))
+def detect_mime_type_tika(col):
+    sc = SparkContext.getOrCreate()
+    udf = (
+        sc.getOrCreate()
+        ._jvm.io.archivesunleashed.udfs.package.detectMimeTypeTika()
+        .apply
+    )
+    return Column(udf(_to_seq(sc, [col], _to_java_column)))
 
-    def extract_links(col, links):
-        sc = SparkContext.getOrCreate()
-        udf = (
-            sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.extractLinks().apply
-        )
-        return Column(udf(_to_seq(sc, [col, links], _to_java_column)))
 
-    def get_extension_mime(col, mime):
-        sc = SparkContext.getOrCreate()
-        udf = (
-            sc.getOrCreate()
-            ._jvm.io.archivesunleashed.udfs.package.getExtensionMime()
-            .apply
-        )
-        return Column(udf(_to_seq(sc, [col, mime], _to_java_column)))
+def extract_boilerplate(col):
+    sc = SparkContext.getOrCreate()
+    udf = (
+        sc.getOrCreate()
+        ._jvm.io.archivesunleashed.udfs.package.extractBoilerpipeText()
+        .apply
+    )
+    return Column(udf(_to_seq(sc, [col], _to_java_column)))
 
-    def remove_http_header(col):
-        sc = SparkContext.getOrCreate()
-        udf = (
-            sc.getOrCreate()
-            ._jvm.io.archivesunleashed.udfs.package.removeHTTPHeader()
-            .apply
-        )
-        return Column(udf(_to_seq(sc, [col], _to_java_column)))
 
-    def remove_html(col):
-        sc = SparkContext.getOrCreate()
-        udf = sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.removeHTML().apply
-        return Column(udf(_to_seq(sc, [col], _to_java_column)))
+def extract_date(col, dates):
+    sc = SparkContext.getOrCreate()
+    udf = sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.extractDate().apply
+    return Column(udf(_to_seq(sc, [col], _to_java_column)))
 
-    def remove_prefix_www(col):
-        sc = SparkContext.getOrCreate()
-        udf = (
-            sc.getOrCreate()
-            ._jvm.io.archivesunleashed.udfs.package.removePrefixWWW()
-            .apply
-        )
-        return Column(udf(_to_seq(sc, [col], _to_java_column)))
+
+def extract_domain(col):
+    sc = SparkContext.getOrCreate()
+    udf = sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.extractDomain().apply
+    return Column(udf(_to_seq(sc, [col], _to_java_column)))
+
+
+def extract_image_links(col, image_links):
+    sc = SparkContext.getOrCreate()
+    udf = (
+        sc.getOrCreate()
+        ._jvm.io.archivesunleashed.udfs.package.extractImageLinks()
+        .apply
+    )
+    return Column(udf(_to_seq(sc, [col, image_links], _to_java_column)))
+
+
+def extract_links(col, links):
+    sc = SparkContext.getOrCreate()
+    udf = sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.extractLinks().apply
+    return Column(udf(_to_seq(sc, [col, links], _to_java_column)))
+
+
+def get_extension_mime(col, mime):
+    sc = SparkContext.getOrCreate()
+    udf = (
+        sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.getExtensionMime().apply
+    )
+    return Column(udf(_to_seq(sc, [col, mime], _to_java_column)))
+
+
+def remove_http_header(col):
+    sc = SparkContext.getOrCreate()
+    udf = (
+        sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.removeHTTPHeader().apply
+    )
+    return Column(udf(_to_seq(sc, [col], _to_java_column)))
+
+
+def remove_html(col):
+    sc = SparkContext.getOrCreate()
+    udf = sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.removeHTML().apply
+    return Column(udf(_to_seq(sc, [col], _to_java_column)))
+
+
+def remove_prefix_www(col):
+    sc = SparkContext.getOrCreate()
+    udf = (
+        sc.getOrCreate()._jvm.io.archivesunleashed.udfs.package.removePrefixWWW().apply
+    )
+    return Column(udf(_to_seq(sc, [col], _to_java_column)))


### PR DESCRIPTION
**GitHub issue(s)**: #467

# What does this Pull Request do?

Move Python UDF methods out of their own class.

- Resolve #467
- README button colour tweak for UserDocs

# How should this be tested?

- [Notebooks updated for testing](https://github.com/archivesunleashed/notebooks/commit/cbcfb951f2f9c995748e6f8fac2cb5ddd2d08f14)
  - [AUT PySpark Documentation Examples](https://github.com/archivesunleashed/notebooks/blob/master/aut-pyspark-documentation-examples.ipynb)
  - [PySpark - aut standard derivatives.ipynb](https://github.com/archivesunleashed/notebooks/blob/master/PySpark%20-%20aut%20standard%20derivatives.ipynb)
- Documentation PR https://github.com/archivesunleashed/aut-docs/pull/66
