### PR TITLE
ars-cloud compatibility with aut and Java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following two articles provide an overview of the project:
 
 - Java 11
 - Python 3.7.3+ (PySpark)
+- Scala 2.12+
 - Apache Spark 3.0.0+
 
  More information on setting up dependencies can be found [here](https://aut.docs.archivesunleashed.org/docs/next/dependencies).

--- a/pom.xml
+++ b/pom.xml
@@ -433,11 +433,23 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-core</artifactId>
       <version>${hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
# What does this Pull Request do?

- Exclude servlet-api from the Hadoop dependency tree.
- Add Scala version requirement to README.

# How should this be tested?

- Build tests (GitHub Actions)
- @helgeho you can use this branch of Java 11 testing with ars-cloud.

I can keep this PR open as a staging ground for tweaks for ars-cloud working Java 11 and `aut` on the `main` branch.

