### PR TITLE
Replace scala-uri library from ExtractDomain.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,14 +108,6 @@
                 </transformer>
               </transformers>
 
-              <!-- Shade cats per: https://github.com/lemonlabsuk/scala-uri/issues/341#issuecomment-918529726-->
-              <relocations>
-                <relocation>
-                  <pattern>cats.</pattern>
-                  <shadedPattern>cats.shaded.</shadedPattern>
-                </relocation>
-              </relocations>
-
               <!-- This fixes the issue "Invalid signature file digest for Manifest main attributes"
                    cf. http://zhentao-li.blogspot.com/2012/06/maven-shade-plugin-invalid-signature.html -->
               <filters>
@@ -583,11 +575,6 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-aws</artifactId>
       <version>${hadoop.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.lemonlabs</groupId>
-      <artifactId>scala-uri_${scala.binary.version}</artifactId>
-      <version>3.5.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
**GitHub issue(s)**: #521 

# What does this Pull Request do?

Replace scala-uri library from ExtractDomain.

- Pull down public_suffix_list.dat, and parse it to ExtractDomain
  instead of using scala-uri
- Remove scala-uri
- Remove cats shading
- Resolves #521

# How should this be tested?

* GitHub actions
* Tested on tuna too:

```scala
import io.archivesunleashed._
import io.archivesunleashed.udfs._
import io.archivesunleashed.app._

val webpages = RecordLoader.loadArchives("/tuna1/scratch/nruest/5467/warcs/gzip/*", sc).webpages()

val domain_count = webpages.groupBy(removePrefixWWW(extractDomain($"Url")).alias("url")).count().sort($"count".desc)

domain_count.show(false)
```

```
+------------------------+-----+                                                
|url                     |count|
+------------------------+-----+
|bbc.com                 |57707|
|bbc.co.uk               |36096|
|winnipegfreepress.com   |25258|
|cbc.ca                  |3755 |
|1winnipeg.ca            |1881 |
|ctvnews.ca              |1377 |
|twitter.com             |1347 |
|macleans.ca             |964  |
|youtube.com             |728  |
|huffingtonpost.ca       |403  |
|communitynewscommons.org|201  |
|soundcloud.com          |137  |
|huffingtonpost.com      |72   |
|globalnews.ca           |67   |
|doubleclick.net         |66   |
|google.com              |58   |
|metronews.ca            |52   |
|livestream.com          |46   |
|workopolis.com          |41   |
|vancouvertrails.com     |25   |
+------------------------+-----+
only showing top 20 rows
```

h/t @helgeho for implementing this on ARCH :pray: 

