### PR TITLE
Fix codecov GitHub action.

### DIFF
--- a/.github/workflows/mvn-build.yml
+++ b/.github/workflows/mvn-build.yml
@@ -19,5 +19,6 @@ jobs:
           mvn javadoc:jar
           mvn javadoc:test-aggregate
           mvn site
-      - name: Upload coverage report to Codecov
-        run: bash <(curl -s https://codecov.io/bash)
+      - name: Upload coverage to Codecov
+        uses: actions/checkout@master
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/mvn-build.yml
+++ b/.github/workflows/mvn-build.yml
@@ -20,5 +20,6 @@ jobs:
           mvn javadoc:test-aggregate
           mvn site
       - name: Upload coverage to Codecov
-        uses: actions/checkout@master
         uses: codecov/codecov-action@v2
+        with:
+          verbose: true


### PR DESCRIPTION
Codecov wasn't getting updated correctly because of deprecations on there end that I missed: https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1=

This should do it. Let's see if it builds and reports. If everything looks good, I'll merge.