### PR TITLE
Make webpages() consistent across aut and ARCH.

### DIFF
--- a/.github/workflows/mvn-build.yml
+++ b/.github/workflows/mvn-build.yml
@@ -19,5 +19,7 @@ jobs:
           mvn javadoc:jar
           mvn javadoc:test-aggregate
           mvn site
-      - name: Upload coverage report to Codecov
-        run: bash <(curl -s https://codecov.io/bash)
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          verbose: true

--- a/.github/workflows/mvn-build.yml
+++ b/.github/workflows/mvn-build.yml
@@ -1,6 +1,8 @@
 name: Maven build
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you would like a more in-depth look at the project, please check out the foll
 - Java 11
 - Python 3.7.3+ (PySpark)
 - Scala 2.12+
-- Apache Spark 3.0.0+
+- Apache Spark (Hadoop 2.7) 3.0.3+
 
  More information on setting up dependencies can be found [here](https://aut.docs.archivesunleashed.org/docs/next/dependencies).
 

--- a/src/main/scala/io/archivesunleashed/app/CommandLineApp.scala
+++ b/src/main/scala/io/archivesunleashed/app/CommandLineApp.scala
@@ -20,7 +20,7 @@ import java.nio.file.{Files, Paths}
 
 import io.archivesunleashed.{ArchiveRecord, RecordLoader}
 import org.apache.log4j.Logger
-import org.apache.spark.sql.{Dataset, Row}
+import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.apache.spark.{SparkConf, SparkContext}
 import org.rogach.scallop.exceptions.ScallopException
 import org.rogach.scallop.ScallopConf
@@ -209,9 +209,9 @@ class CommandLineApp(conf: CmdAppConf) {
     "PlainTextExtractor" ->
       ((inputFiles: List[String]) => {
         var df =
-          RecordLoader.loadArchives(inputFiles.head, sparkCtx.get).webpages()
+          RecordLoader.loadArchives(inputFiles.head, sparkCtx.get).all()
         inputFiles.tail foreach { f =>
-          df = df.union(RecordLoader.loadArchives(f, sparkCtx.get).webpages())
+          df = df.union(RecordLoader.loadArchives(f, sparkCtx.get).all())
         }
         if (!configuration.outputFormat.isEmpty && configuration
               .outputFormat() == "parquet") {
@@ -327,12 +327,19 @@ class CommandLineApp(conf: CmdAppConf) {
       d.coalesce(configuration.partition())
         .write
         .option("timestampFormat", "yyyy/MM/dd HH:mm:ss ZZ")
+        .format("csv")
         .option("header", "true")
-        .csv(saveTarget)
+        .option("escape", "\"")
+        .option("encoding", "utf-8")
+        .save(saveTarget)
     } else {
       d.write
         .option("timestampFormat", "yyyy/MM/dd HH:mm:ss ZZ")
-        .csv(saveTarget)
+        .format("csv")
+        .option("header", "true")
+        .option("escape", "\"")
+        .option("encoding", "utf-8")
+        .save(saveTarget)
     }
   }
 

--- a/src/main/scala/io/archivesunleashed/app/CommandLineApp.scala
+++ b/src/main/scala/io/archivesunleashed/app/CommandLineApp.scala
@@ -336,7 +336,6 @@ class CommandLineApp(conf: CmdAppConf) {
       d.write
         .option("timestampFormat", "yyyy/MM/dd HH:mm:ss ZZ")
         .format("csv")
-        .option("header", "true")
         .option("escape", "\"")
         .option("encoding", "utf-8")
         .save(saveTarget)

--- a/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
@@ -46,6 +46,6 @@ object PlainTextExtractor {
         !(lower($"url").startsWith("filedesc:"))
           && (!(lower($"url").startsWith("dns:")))
       )
-      .select(extractBoilerpipeText($"content").as("content"))
+      .select(extractBoilerpipeText($"raw_content").as("content"))
   }
 }

--- a/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
@@ -19,19 +19,33 @@ package io.archivesunleashed.app
 import io.archivesunleashed.ArchiveRecord
 import io.archivesunleashed.udfs.{extractBoilerpipeText}
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.functions.lower
 
 object PlainTextExtractor {
 
   /** Extract plain text from web archive using DataFrame and Spark SQL.
     *
     * @param d DataFrame obtained from RecordLoader
-    * @return Dataset[Row], where the schema is (crawl date, domain, url, text)
+    * @return Dataset[Row], where the schema is (content)
     */
   def apply(d: DataFrame): Dataset[Row] = {
     val spark = SparkSession.builder().master("local").getOrCreate()
     // scalastyle:off
     import spark.implicits._
     // scalastyle:on
-    d.select(extractBoilerpipeText($"content").as("content"))
+    d.filter($"crawl_date" isNotNull)
+      .filter(
+        !($"url".rlike(".*robots\\.txt$")) &&
+          ($"mime_type_web_server".rlike("text/html") ||
+            $"mime_type_web_server".rlike("application/xhtml+xml") ||
+            $"url".rlike("(?i).*htm$") ||
+            $"url".rlike("(?i).*html$"))
+      )
+      .filter($"http_status_code" === 200)
+      .filter(
+        !(lower($"url").startsWith("filedesc:"))
+          && (!(lower($"url").startsWith("dns:")))
+      )
+      .select(extractBoilerpipeText($"content").as("content"))
   }
 }

--- a/src/main/scala/io/archivesunleashed/app/WebPagesExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/WebPagesExtractor.scala
@@ -40,12 +40,12 @@ object WebPagesExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
-      removePrefixWWW(extractDomain($"url")).as("domain"),
+      $"domain",
       $"url",
       $"mime_type_web_server",
       $"mime_type_tika",
       $"language",
-      removeHTML(removeHTTPHeader(($"content"))).alias("content")
+      $"content"
     )
   }
 }

--- a/src/main/scala/io/archivesunleashed/df/DataFrameLoader.scala
+++ b/src/main/scala/io/archivesunleashed/df/DataFrameLoader.scala
@@ -32,7 +32,9 @@ class DataFrameLoader(sc: SparkContext) {
 
   /** Create a DataFrame with audio url, filename, extension, mime_type_web_server, mime_type_tika, md5, sha1, and raw bytes. */
   def audio(path: String): DataFrame = {
-    RecordLoader.loadArchives(path, sc).audio
+    RecordLoader
+      .loadArchives(path, sc)
+      .audio()
   }
 
   /* Create a DataFrame with crawl date, source page, image url, and alt text. */
@@ -51,22 +53,30 @@ class DataFrameLoader(sc: SparkContext) {
 
   /** Create a DataFrame with PDF url, filename, extension, mime_type_web_server, mime_type_tika, md5, sha1, and raw bytes. */
   def pdfs(path: String): DataFrame = {
-    RecordLoader.loadArchives(path, sc).pdfs
+    RecordLoader
+      .loadArchives(path, sc)
+      .pdfs()
   }
 
   /** Create a DataFrame with presentation program file url, filename, extension, mime_type_web_server, mime_type_tika, md5, sha1, and raw bytes. */
   def presentationProgramFiles(path: String): DataFrame = {
-    RecordLoader.loadArchives(path, sc).presentationProgramFiles
+    RecordLoader
+      .loadArchives(path, sc)
+      .presentationProgramFiles()
   }
 
   /** Create a DataFrame with spreadsheet url, filename, extension, mime_type_web_server, mime_type_tika, md5, sha1, and raw bytes. */
   def spreadsheets(path: String): DataFrame = {
-    RecordLoader.loadArchives(path, sc).spreadsheets
+    RecordLoader
+      .loadArchives(path, sc)
+      .spreadsheets()
   }
 
   /** Create a DataFrame with video url, filename, extension, mime_type_web_server, mime_type_tika, md5, sha1, and raw bytes. */
   def videos(path: String): DataFrame = {
-    RecordLoader.loadArchives(path, sc).videos
+    RecordLoader
+      .loadArchives(path, sc)
+      .videos()
   }
 
   /** Create a DataFrame with crawl_date, source, destination, and anchor. */
@@ -85,6 +95,8 @@ class DataFrameLoader(sc: SparkContext) {
 
   /** Create a DataFrame with word processor file url, filename, extension, mime_type_web_server, mime_type_tika, md5, sha1, and raw bytes. */
   def wordProcessorFiles(path: String): DataFrame = {
-    RecordLoader.loadArchives(path, sc).wordProcessorFiles
+    RecordLoader
+      .loadArchives(path, sc)
+      .wordProcessorFiles()
   }
 }

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -187,7 +187,7 @@ package object archivesunleashed {
         .add(StructField("url", StringType, true))
         .add(StructField("mime_type_web_server", StringType, true))
         .add(StructField("mime_type_tika", StringType, true))
-        .add(StructField("content", StringType, true))
+        .add(StructField("raw_content", StringType, true))
         .add(StructField("bytes", BinaryType, true))
         .add(StructField("http_status_code", StringType, true))
         .add(StructField("archive_filename", StringType, true))

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -41,7 +41,7 @@ import org.apache.commons.codec.binary.Hex
 import org.apache.commons.io.FilenameUtils
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.functions.{lit, udf}
+import org.apache.spark.sql.functions.{lit, lower, udf}
 import org.apache.spark.sql.types.{
   BinaryType,
   IntegerType,
@@ -170,6 +170,7 @@ package object archivesunleashed {
         .map(r =>
           Row(
             r.getCrawlDate,
+            ExtractDomain(r.getUrl).replaceAll("^\\s*www\\.", ""),
             r.getUrl,
             r.getMimeType,
             DetectMimeTypeTika(r.getBinaryBytes),
@@ -182,6 +183,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("domain", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("mime_type_web_server", StringType, true))
         .add(StructField("mime_type_tika", StringType, true))
@@ -228,7 +230,7 @@ package object archivesunleashed {
             r.getMimeType,
             DetectMimeTypeTika(r.getBinaryBytes),
             DetectLanguage(RemoveHTML(RemoveHTTPHeader(r.getContentString))),
-            r.getContentString
+            RemoveHTML(RemoveHTTPHeader(r.getContentString))
           )
         )
 

--- a/src/test/scala/io/archivesunleashed/RecordDFTest.scala
+++ b/src/test/scala/io/archivesunleashed/RecordDFTest.scala
@@ -180,8 +180,8 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
     val base = RecordLoader
       .loadArchives(arcPath, sc)
       .all()
-      .select($"url", $"content")
-      .filter(hasContent($"content", lit(Array("Content-Length: [0-9]{4}"))))
+      .select($"url", $"raw_content")
+      .filter(hasContent($"raw_content", lit(Array("Content-Length: [0-9]{4}"))))
       .take(1)(0)(0)
 
     assert(base.toString == expected)
@@ -223,10 +223,10 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
     val base = RecordLoader
       .loadArchives(arcPath, sc)
       .all()
-      .select(detectLanguage(removeHTML($"content")).as("language"))
+      .select(detectLanguage(removeHTML($"raw_content")).as("language"))
       .filter(
         hasLanguages(
-          detectLanguage(removeHTML($"content")),
+          detectLanguage(removeHTML($"raw_content")),
           lit(Array("de", "ht"))
         )
       )

--- a/src/test/scala/io/archivesunleashed/RecordDFTest.scala
+++ b/src/test/scala/io/archivesunleashed/RecordDFTest.scala
@@ -34,7 +34,7 @@ import io.archivesunleashed.udfs.{
 }
 import com.google.common.io.Resources
 import org.apache.spark.sql.functions.lit
-import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.{SparkConf, SparkContext}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -61,7 +61,7 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
       .loadArchives(arcPath, sc)
       .all()
       .keepValidPagesDF()
-      .take(1)(0)(1)
+      .take(2)(0)(2)
 
     assert(base.toString == expected)
   }

--- a/src/test/scala/io/archivesunleashed/RecordDFTest.scala
+++ b/src/test/scala/io/archivesunleashed/RecordDFTest.scala
@@ -181,7 +181,9 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
       .loadArchives(arcPath, sc)
       .all()
       .select($"url", $"raw_content")
-      .filter(hasContent($"raw_content", lit(Array("Content-Length: [0-9]{4}"))))
+      .filter(
+        hasContent($"raw_content", lit(Array("Content-Length: [0-9]{4}")))
+      )
       .take(1)(0)(0)
 
     assert(base.toString == expected)

--- a/src/test/scala/io/archivesunleashed/app/PlainTextExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/PlainTextExtractorTest.scala
@@ -39,7 +39,7 @@ class PlainTextExtractorTest extends FunSuite with BeforeAndAfter {
   }
 
   test("Plain text extractor") {
-    val df = RecordLoader.loadArchives(arcPath, sc).webpages()
+    val df = RecordLoader.loadArchives(arcPath, sc).all()
     val dfResults = PlainTextExtractor(df).collect()
     val RESULTSLENGTH = 94
 

--- a/src/test/scala/io/archivesunleashed/df/ExtractDateDFTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractDateDFTest.scala
@@ -47,7 +47,8 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
   test("Extract dates YYYY DF") {
     val df = RecordLoader
       .loadArchives(arcPath, sc)
-      .webpages()
+      .all()
+      .keepValidPagesDF()
 
     val dest = udf((vs: Seq[Any]) => vs(0).toString.split(",")(1))
 
@@ -60,19 +61,19 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
 
     val interResults = df
       .select(
-        removePrefixWWW(extractDomain($"url")).as("Domain"),
-        $"url".as("url"),
+        $"domain",
+        $"url",
         extractDate($"crawl_date", lit("YYYY")).as("crawl_date"),
         explode_outer(extractLinks($"url", $"content")).as("link")
       )
       .filter(
         lower($"content").contains("keynote")
-      ) // filtered on keyword internet
+      )
 
     val results = interResults
       .select(
         $"url",
-        $"Domain",
+        $"domain",
         $"crawl_date",
         dest(array($"link")).as("destination_page")
       )
@@ -101,7 +102,8 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
   test("Extract dates YYYYMM DF") {
     val df = RecordLoader
       .loadArchives(arcPath, sc)
-      .webpages()
+      .all()
+      .keepValidPagesDF()
 
     val dest = udf((vs: Seq[Any]) => vs(0).toString.split(",")(1))
 
@@ -114,8 +116,8 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
 
     val interResults = df
       .select(
-        removePrefixWWW(extractDomain($"url")).as("Domain"),
-        $"url".as("url"),
+        $"domain",
+        $"url",
         extractDate($"crawl_date", lit("YYYYMM")).as("crawl_date"),
         explode_outer(extractLinks($"url", $"content")).as("link")
       )
@@ -126,7 +128,7 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
     val results = interResults
       .select(
         $"url",
-        $"Domain",
+        $"domain",
         $"crawl_date",
         dest(array($"link")).as("destination_page")
       )
@@ -155,7 +157,8 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
   test("Extract dates MM DF") {
     val df = RecordLoader
       .loadArchives(arcPath, sc)
-      .webpages()
+      .all()
+      .keepValidPagesDF()
 
     val dest = udf((vs: Seq[Any]) => vs(0).toString.split(",")(1))
 
@@ -168,19 +171,19 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
 
     val interResults = df
       .select(
-        removePrefixWWW(extractDomain($"url")).as("Domain"),
-        $"url".as("url"),
+        $"domain",
+        $"url",
         extractDate($"crawl_date", lit("MM")).as("crawl_date"),
         explode_outer(extractLinks($"url", $"content")).as("link")
       )
       .filter(
         lower($"content").contains("keynote")
-      ) // filtered on keyword internet
+      )
 
     val results = interResults
       .select(
         $"url",
-        $"Domain",
+        $"domain",
         $"crawl_date",
         dest(array($"link")).as("destination_page")
       )
@@ -209,7 +212,8 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
   test("Extract dates DD DF") {
     val df = RecordLoader
       .loadArchives(arcPath, sc)
-      .webpages()
+      .all()
+      .keepValidPagesDF()
 
     val dest = udf((vs: Seq[Any]) => vs(0).toString.split(",")(1))
 
@@ -222,19 +226,19 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
 
     val interResults = df
       .select(
-        removePrefixWWW(extractDomain($"url")).as("Domain"),
-        $"url".as("url"),
+        $"domain",
+        $"url",
         extractDate($"crawl_date", lit("DD")).as("crawl_date"),
         explode_outer(extractLinks($"url", $"content")).as("link")
       )
       .filter(
         lower($"content").contains("keynote")
-      ) // filtered on keyword internet
+      )
 
     val results = interResults
       .select(
         $"url",
-        $"Domain",
+        $"domain",
         $"crawl_date",
         dest(array($"link")).as("destination_page")
       )
@@ -263,7 +267,8 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
   test("Extract dates YYYYMMDD DF") {
     val df = RecordLoader
       .loadArchives(arcPath, sc)
-      .webpages()
+      .all()
+      .keepValidPagesDF()
 
     val dest = udf((vs: Seq[Any]) => vs(0).toString.split(",")(1))
 
@@ -276,19 +281,19 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
 
     val interResults = df
       .select(
-        removePrefixWWW(extractDomain($"url")).as("Domain"),
-        $"url".as("url"),
+        $"domain",
+        $"url",
         extractDate($"crawl_date", lit("YYYYMMDDHHMMSS")).as("crawl_date"),
         explode_outer(extractLinks($"url", $"content")).as("link")
       )
       .filter(
         lower($"content").contains("keynote")
-      ) // filtered on keyword internet
+      )
 
     val results = interResults
       .select(
         $"url",
-        $"Domain",
+        $"domain",
         $"crawl_date",
         dest(array($"link")).as("destination_page")
       )

--- a/src/test/scala/io/archivesunleashed/df/ExtractDateDFTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractDateDFTest.scala
@@ -64,10 +64,10 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
         $"domain",
         $"url",
         extractDate($"crawl_date", lit("YYYY")).as("crawl_date"),
-        explode_outer(extractLinks($"url", $"content")).as("link")
+        explode_outer(extractLinks($"url", $"raw_content")).as("link")
       )
       .filter(
-        lower($"content").contains("keynote")
+        lower($"raw_content").contains("keynote")
       )
 
     val results = interResults
@@ -119,10 +119,10 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
         $"domain",
         $"url",
         extractDate($"crawl_date", lit("YYYYMM")).as("crawl_date"),
-        explode_outer(extractLinks($"url", $"content")).as("link")
+        explode_outer(extractLinks($"url", $"raw_content")).as("link")
       )
       .filter(
-        lower($"content").contains("keynote")
+        lower($"raw_content").contains("keynote")
       ) // filtered on keyword internet
 
     val results = interResults
@@ -174,10 +174,10 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
         $"domain",
         $"url",
         extractDate($"crawl_date", lit("MM")).as("crawl_date"),
-        explode_outer(extractLinks($"url", $"content")).as("link")
+        explode_outer(extractLinks($"url", $"raw_content")).as("link")
       )
       .filter(
-        lower($"content").contains("keynote")
+        lower($"raw_content").contains("keynote")
       )
 
     val results = interResults
@@ -229,10 +229,10 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
         $"domain",
         $"url",
         extractDate($"crawl_date", lit("DD")).as("crawl_date"),
-        explode_outer(extractLinks($"url", $"content")).as("link")
+        explode_outer(extractLinks($"url", $"raw_content")).as("link")
       )
       .filter(
-        lower($"content").contains("keynote")
+        lower($"raw_content").contains("keynote")
       )
 
     val results = interResults
@@ -284,10 +284,10 @@ class ExtractDateDFTest extends FunSuite with BeforeAndAfter {
         $"domain",
         $"url",
         extractDate($"crawl_date", lit("YYYYMMDDHHMMSS")).as("crawl_date"),
-        explode_outer(extractLinks($"url", $"content")).as("link")
+        explode_outer(extractLinks($"url", $"raw_content")).as("link")
       )
       .filter(
-        lower($"content").contains("keynote")
+        lower($"raw_content").contains("keynote")
       )
 
     val results = interResults

--- a/src/test/scala/io/archivesunleashed/df/ExtractHyperlinksTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractHyperlinksTest.scala
@@ -42,7 +42,8 @@ class ExtractHyperlinksTest extends FunSuite with BeforeAndAfter {
   test("Extract links DF") {
     val df = RecordLoader
       .loadArchives(arcPath, sc)
-      .webpages()
+      .all()
+      .keepValidPagesDF()
 
     val dest = udf((vs: Seq[Any]) => vs(0).toString.split(",")(1))
 
@@ -54,19 +55,19 @@ class ExtractHyperlinksTest extends FunSuite with BeforeAndAfter {
 
     val interResults = df
       .select(
-        removePrefixWWW(extractDomain($"url")).as("Domain"),
-        $"url".as("url"),
+        $"domain",
+        $"url",
         $"crawl_date",
         explode_outer(extractLinks($"url", $"content")).as("link")
       )
       .filter(
         lower($"content").contains("keynote")
-      ) // filtered on keyword internet
+      )
 
     val results = interResults
       .select(
         $"url",
-        $"Domain",
+        $"domain",
         $"crawl_date",
         dest(array($"link")).as("destination_page")
       )

--- a/src/test/scala/io/archivesunleashed/df/ExtractHyperlinksTest.scala
+++ b/src/test/scala/io/archivesunleashed/df/ExtractHyperlinksTest.scala
@@ -58,10 +58,10 @@ class ExtractHyperlinksTest extends FunSuite with BeforeAndAfter {
         $"domain",
         $"url",
         $"crawl_date",
-        explode_outer(extractLinks($"url", $"content")).as("link")
+        explode_outer(extractLinks($"url", $"raw_content")).as("link")
       )
       .filter(
-        lower($"content").contains("keynote")
+        lower($"raw_content").contains("keynote")
       )
 
     val results = interResults

--- a/src/test/scala/io/archivesunleashed/df/UdfsTests.scala
+++ b/src/test/scala/io/archivesunleashed/df/UdfsTests.scala
@@ -50,7 +50,8 @@ class UdfsTest extends FunSuite with BeforeAndAfter {
   ) {
     val df = RecordLoader
       .loadArchives(arcPath, sc)
-      .webpages()
+      .all()
+      .keepValidPagesDF()
 
     // We need this in order to use the $-notation
     val spark = SparkSession.builder().master("local").getOrCreate()

--- a/src/test/scala/io/archivesunleashed/df/UdfsTests.scala
+++ b/src/test/scala/io/archivesunleashed/df/UdfsTests.scala
@@ -64,9 +64,9 @@ class UdfsTest extends FunSuite with BeforeAndAfter {
         $"url",
         $"mime_type_web_server",
         $"mime_type_tika",
-        computeSHA1($"content").as("sha1_test"),
-        computeMD5($"content").as("md5_test"),
-        explode(extractImageLinks($"url", $"content")).as("image_link"),
+        computeSHA1($"raw_content").as("sha1_test"),
+        computeMD5($"raw_content").as("md5_test"),
+        explode(extractImageLinks($"url", $"raw_content")).as("image_link"),
         getExtensionMime($"url", $"mime_type_tika").as("extension")
       )
       .orderBy(desc("md5_test"))


### PR DESCRIPTION
**GitHub issue(s)**:

* #538

# What does this Pull Request do?

Make webpages() consistent across aut and ARCH.

- Filter HTTP headers, and HTML from content on webpages so that it is consistent with the app implementation, and the ARCH implementation
- Update PlainTextExtractor to use .all() since HTML is removed from content
- Add domain to all()
- Update csv exports on app so that they are rfc4180 compliant
- Apply GitHub workflows to main branch
- Consistent formating on DataFrameLoader.scala
- Update tests as needed
- Resolves #538

# How should this be tested?

* GitHub actions build
* Testing using documentation updates: https://github.com/archivesunleashed/aut-docs/pull/117
