### PR TITLE
Use YYYYMMDD for crawl_date for DomainGraphExtractor.

### DIFF
--- a/src/main/scala/io/archivesunleashed/app/DomainGraphExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/DomainGraphExtractor.scala
@@ -19,7 +19,7 @@ package io.archivesunleashed.app
 import io.archivesunleashed.ArchiveRecord
 import io.archivesunleashed.df.DataFrameLoader
 import io.archivesunleashed.udfs.{extractDomain, removePrefixWWW}
-import org.apache.spark.sql.functions.desc
+import org.apache.spark.sql.functions.{desc, substring}
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 
 object DomainGraphExtractor {
@@ -35,7 +35,7 @@ object DomainGraphExtractor {
     import spark.implicits._
     // scalastyle:on
     d.groupBy(
-        $"crawl_date",
+        substring($"crawl_date", 0, 8).as("crawl_date"),
         removePrefixWWW(extractDomain($"src")).as("src_domain"),
         removePrefixWWW(extractDomain($"dest")).as("dest_domain")
       )

--- a/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
@@ -20,6 +20,7 @@ import io.archivesunleashed.ArchiveRecord
 import io.archivesunleashed.udfs.{extractBoilerpipeText}
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.functions.lower
+import scala.language.postfixOps
 
 object PlainTextExtractor {
 

--- a/src/test/scala/io/archivesunleashed/app/DomainGraphExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/DomainGraphExtractorTest.scala
@@ -39,21 +39,21 @@ class DomainGraphExtractorDfTest extends FunSuite with BeforeAndAfter {
   }
 
   test("Domain graph extractor DF") {
-    val TESTLENGTH = 82
+    val TESTLENGTH = 10
     val df = RecordLoader.loadArchives(arcPath, sc).webgraph()
     val dfResult = DomainGraphExtractor(df).collect()
 
     assert(dfResult.length == TESTLENGTH)
 
-    assert(dfResult(0).get(0) == "20080430205151")
+    assert(dfResult(0).get(0) == "20080430")
     assert(dfResult(0).get(1) == "archive.org")
     assert(dfResult(0).get(2) == "archive.org")
-    assert(dfResult(0).get(3) == 10566)
+    assert(dfResult(0).get(3) == 37511)
 
-    assert(dfResult(1).get(0) == "20080430204948")
+    assert(dfResult(1).get(0) == "20080430")
     assert(dfResult(1).get(1) == "archive.org")
-    assert(dfResult(1).get(2) == "archive.org")
-    assert(dfResult(1).get(3) == 7143)
+    assert(dfResult(1).get(2) == "etree.org")
+    assert(dfResult(1).get(3) == 31)
   }
 
   after {


### PR DESCRIPTION
**GitHub issue(s)**: #544

# What does this Pull Request do?

- Resolves #544
- Update DomainGraphExtractor test
- Add import scala.language.postfixOps to resolve "postfix operator isNotNull should be enabled by making the implicit value scala.language.postfixOps visible."

# How should this be tested?

Tests should take care of it.

I'll cut a 1.1.1 release once we get this merged.
