### PR TITLE
Last modified headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -564,9 +564,9 @@
       <version>${hadoop.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.ruebot</groupId>
+      <groupId>com.github.internetarchive</groupId>
       <artifactId>Sparkling</artifactId>
-      <version>last-modified-headers-6569515a55-1</version>
+      <version>main-f002a0509e-1</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -564,9 +564,9 @@
       <version>${hadoop.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.internetarchive</groupId>
+      <groupId>com.github.ruebot</groupId>
       <artifactId>Sparkling</artifactId>
-      <version>main-f002a0509e-1</version>
+      <version>last-modified-headers-6569515a55-1</version>
     </dependency>
   </dependencies>
 

--- a/src/main/scala/io/archivesunleashed/ArchiveRecord.scala
+++ b/src/main/scala/io/archivesunleashed/ArchiveRecord.scala
@@ -48,4 +48,7 @@ trait ArchiveRecord extends Serializable {
 
   /** Returns payload digest (SHA1). */
   def getPayloadDigest: String
+
+  /** Returns last-modified date from HTTPS headers as a string. */
+  def getLastModified: String
 }

--- a/src/main/scala/io/archivesunleashed/SparklingArchiveRecord.scala
+++ b/src/main/scala/io/archivesunleashed/SparklingArchiveRecord.scala
@@ -66,7 +66,7 @@ class SparklingArchiveRecord(
 
   override def getLastModified: String =
     http(warc)
-      .flatMap(_.lastModified)
+      .flatMap(_.headerMap.get("last-modified"))
       .getOrElse("")
 
   override def getArchiveFilename: String = filename

--- a/src/main/scala/io/archivesunleashed/SparklingArchiveRecord.scala
+++ b/src/main/scala/io/archivesunleashed/SparklingArchiveRecord.scala
@@ -22,7 +22,11 @@ import io.archivesunleashed.matchbox.ExtractDomain
 import org.apache.tika.io.BoundedInputStream
 import org.archive.webservices.sparkling.http.HttpMessage
 import org.archive.webservices.sparkling.io.IOUtil
-import org.archive.webservices.sparkling.util.{ManagedVal, ValueSupplier}
+import org.archive.webservices.sparkling.util.{
+  ManagedVal,
+  RegexUtil,
+  ValueSupplier
+}
 import org.archive.webservices.sparkling.warc.{WarcHeaders, WarcRecord}
 import scala.util.Try
 
@@ -59,6 +63,11 @@ class SparklingArchiveRecord(
   def limitBodyLength(maxBodyLength: Long): SparklingArchiveRecord = {
     new SparklingArchiveRecord(filename, meta, payload, maxBodyLength)
   }
+
+  override def getLastModified: String =
+    http(warc)
+      .flatMap(_.lastModified)
+      .getOrElse("")
 
   override def getArchiveFilename: String = filename
 

--- a/src/main/scala/io/archivesunleashed/app/AudioInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/AudioInformationExtractor.scala
@@ -35,6 +35,7 @@ object AudioInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
+      $"last_modified",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/app/AudioInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/AudioInformationExtractor.scala
@@ -35,7 +35,7 @@ object AudioInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
-      $"last_modified",
+      $"last_modified_date",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/app/ImageInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/ImageInformationExtractor.scala
@@ -35,6 +35,7 @@ object ImageInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
+      $"last_modified",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/app/ImageInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/ImageInformationExtractor.scala
@@ -35,7 +35,7 @@ object ImageInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
-      $"last_modified",
+      $"last_modified_date",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/app/PDFInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PDFInformationExtractor.scala
@@ -35,7 +35,7 @@ object PDFInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
-      $"last_modified",
+      $"last_modified_date",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/app/PDFInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PDFInformationExtractor.scala
@@ -35,6 +35,7 @@ object PDFInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
+      $"last_modified",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PlainTextExtractor.scala
@@ -20,6 +20,7 @@ import io.archivesunleashed.ArchiveRecord
 import io.archivesunleashed.udfs.{extractBoilerpipeText}
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.functions.lower
+import scala.language.postfixOps
 
 object PlainTextExtractor {
 

--- a/src/main/scala/io/archivesunleashed/app/PresentationProgramInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PresentationProgramInformationExtractor.scala
@@ -35,6 +35,7 @@ object PresentationProgramInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
+      $"last_modified",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/app/PresentationProgramInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/PresentationProgramInformationExtractor.scala
@@ -35,7 +35,7 @@ object PresentationProgramInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
-      $"last_modified",
+      $"last_modified_date",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/app/SpreadsheetInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/SpreadsheetInformationExtractor.scala
@@ -35,7 +35,7 @@ object SpreadsheetInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
-      $"last_modified",
+      $"last_modified_date",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/app/SpreadsheetInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/SpreadsheetInformationExtractor.scala
@@ -35,6 +35,7 @@ object SpreadsheetInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
+      $"last_modified",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/app/VideoInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/VideoInformationExtractor.scala
@@ -35,7 +35,7 @@ object VideoInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
-      $"last_modified",
+      $"last_modified_date",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/app/VideoInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/VideoInformationExtractor.scala
@@ -35,6 +35,7 @@ object VideoInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
+      $"last_modified",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/app/WordProcessorInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/WordProcessorInformationExtractor.scala
@@ -35,6 +35,7 @@ object WordProcessorInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
+      $"last_modified",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/app/WordProcessorInformationExtractor.scala
+++ b/src/main/scala/io/archivesunleashed/app/WordProcessorInformationExtractor.scala
@@ -35,7 +35,7 @@ object WordProcessorInformationExtractor {
     // scalastyle:on
     d.select(
       $"crawl_date",
-      $"last_modified",
+      $"last_modified_date",
       $"url",
       $"filename",
       $"extension",

--- a/src/main/scala/io/archivesunleashed/matchbox/CovertLastModifiedDate.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/CovertLastModifiedDate.scala
@@ -15,12 +15,22 @@
  */
 package io.archivesunleashed.matchbox
 
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
-
 /** Converts RFC 1123 dates to yyyyMMddHHmmss. */
 object CovertLastModifiedDate {
-  lazy val outputFormat = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+  val months = Seq(
+    "jan",
+    "feb",
+    "mar",
+    "apr",
+    "may",
+    "jun",
+    "jul",
+    "aug",
+    "sep",
+    "oct",
+    "nov",
+    "dec"
+  ).zipWithIndex.map { case (s, d) => (s, ("0" + (d + 1)).takeRight(2)) }
 
   /** Converts last_modified_date to yyyyMMddHHmmss.
     *
@@ -31,11 +41,25 @@ object CovertLastModifiedDate {
     if (lastModifiedDate.isEmpty) {
       ""
     } else {
-      val d = ZonedDateTime.parse(
-        lastModifiedDate,
-        DateTimeFormatter.RFC_1123_DATE_TIME
-      )
-      outputFormat.format(d)
+      // Credit: Helge Holzmann (@helgeho)
+      // Adapted from https://github.com/archivesunleashed/aut/pull/547#issuecomment-1302094573
+      val lc = lastModifiedDate.toLowerCase
+      val date = months.find(m => lc.contains(m._1)).map(_._2).flatMap { m =>
+        val d = lc
+          .replace(":", "")
+          .split(' ')
+          .drop(1)
+          .map(d => (d.length, d))
+          .toMap
+        for (y <- d.get(4); n <- d.get(2); t <- d.get(6))
+          yield y + m + n + t
+      }
+      date match {
+        case Some(date) =>
+          date
+        case None =>
+          ""
+      }
     }
   }
 }

--- a/src/main/scala/io/archivesunleashed/matchbox/CovertLastModifiedDate.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/CovertLastModifiedDate.scala
@@ -22,10 +22,10 @@ import java.time.format.DateTimeFormatter
 object CovertLastModifiedDate {
   lazy val outputFormat = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
 
-  /** Converts last_modified to yyyyMMddHHmmss.
+  /** Converts last_modified_date to yyyyMMddHHmmss.
     *
     * @param lastModifiedDate date returned by `getLastModified`, formatted as RFC 1123
-    * @return last_modified as yyyyMMddHHmmss.
+    * @return last_modified_date as yyyyMMddHHmmss.
     */
   def apply(lastModifiedDate: String): String = {
     if (lastModifiedDate.isEmpty) {

--- a/src/main/scala/io/archivesunleashed/matchbox/CovertLastModifiedDate.scala
+++ b/src/main/scala/io/archivesunleashed/matchbox/CovertLastModifiedDate.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 The Archives Unleashed Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.archivesunleashed.matchbox
+
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+/** Converts RFC 1123 dates to yyyyMMddHHmmss. */
+object CovertLastModifiedDate {
+  lazy val outputFormat = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+
+  /** Converts last_modified to yyyyMMddHHmmss.
+    *
+    * @param lastModifiedDate date returned by `getLastModified`, formatted as RFC 1123
+    * @return last_modified as yyyyMMddHHmmss.
+    */
+  def apply(lastModifiedDate: String): String = {
+    if (lastModifiedDate.isEmpty) {
+      ""
+    } else {
+      val d = ZonedDateTime.parse(
+        lastModifiedDate,
+        DateTimeFormatter.RFC_1123_DATE_TIME
+      )
+      outputFormat.format(d)
+    }
+  }
+}

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -170,6 +170,7 @@ package object archivesunleashed {
         .map(r =>
           Row(
             r.getCrawlDate,
+            r.getLastModified,
             ExtractDomain(r.getUrl).replaceAll("^\\s*www\\.", ""),
             r.getUrl,
             r.getMimeType,
@@ -183,6 +184,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("domain", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("mime_type_web_server", StringType, true))

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -21,6 +21,7 @@ import java.security.MessageDigest
 import java.util.Base64
 
 import io.archivesunleashed.matchbox.{
+  CovertLastModifiedDate,
   DetectLanguage,
   DetectMimeTypeTika,
   ExtractDate,
@@ -170,7 +171,7 @@ package object archivesunleashed {
         .map(r =>
           Row(
             r.getCrawlDate,
-            r.getLastModified,
+            CovertLastModifiedDate(r.getLastModified),
             ExtractDomain(r.getUrl).replaceAll("^\\s*www\\.", ""),
             r.getUrl,
             r.getMimeType,
@@ -227,6 +228,7 @@ package object archivesunleashed {
         .map(r =>
           Row(
             r.getCrawlDate,
+            CovertLastModifiedDate(r.getLastModified),
             ExtractDomain(r.getUrl).replaceAll("^\\s*www\\.", ""),
             r.getUrl,
             r.getMimeType,
@@ -238,6 +240,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("domain", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("mime_type_web_server", StringType, true))
@@ -306,6 +309,7 @@ package object archivesunleashed {
           val extension = GetExtensionMIME(url.getPath(), mimeTypeTika)
           (
             r.getCrawlDate,
+            CovertLastModifiedDate(r.getLastModified),
             r.getUrl,
             filename,
             extension,
@@ -330,12 +334,14 @@ package object archivesunleashed {
             t._8,
             t._9,
             t._10,
-            t._11
+            t._11,
+            t._12
           )
         )
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -370,6 +376,7 @@ package object archivesunleashed {
           val extension = GetExtensionMIME(url.getPath(), r._2)
           (
             r._1.getCrawlDate,
+            CovertLastModifiedDate(r._1.getLastModified),
             r._1.getUrl,
             filename,
             extension,
@@ -380,10 +387,13 @@ package object archivesunleashed {
             encodedBytes
           )
         })
-        .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9))
+        .map(t =>
+          Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+        )
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -416,6 +426,7 @@ package object archivesunleashed {
           val extension = GetExtensionMIME(url.getPath(), r._2)
           (
             r._1.getCrawlDate,
+            CovertLastModifiedDate(r._1.getLastModified),
             r._1.getUrl,
             filename,
             extension,
@@ -426,10 +437,13 @@ package object archivesunleashed {
             encodedBytes
           )
         })
-        .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9))
+        .map(t =>
+          Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+        )
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -462,6 +476,7 @@ package object archivesunleashed {
           val extension = GetExtensionMIME(url.getPath(), r._2)
           (
             r._1.getCrawlDate,
+            CovertLastModifiedDate(r._1.getLastModified),
             r._1.getUrl,
             filename,
             extension,
@@ -472,10 +487,13 @@ package object archivesunleashed {
             encodedBytes
           )
         })
-        .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9))
+        .map(t =>
+          Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+        )
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -543,6 +561,7 @@ package object archivesunleashed {
           val extension = GetExtensionMIME(url.getPath(), mimeType)
           (
             r._1.getCrawlDate,
+            CovertLastModifiedDate(r._1.getLastModified),
             r._1.getUrl,
             filename,
             extension,
@@ -553,10 +572,13 @@ package object archivesunleashed {
             encodedBytes
           )
         })
-        .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9))
+        .map(t =>
+          Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+        )
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -604,6 +626,7 @@ package object archivesunleashed {
           val extension = GetExtensionMIME(url.getPath(), r._2)
           (
             r._1.getCrawlDate,
+            CovertLastModifiedDate(r._1.getLastModified),
             r._1.getUrl,
             filename,
             extension,
@@ -614,10 +637,13 @@ package object archivesunleashed {
             encodedBytes
           )
         })
-        .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9))
+        .map(t =>
+          Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+        )
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -669,6 +695,7 @@ package object archivesunleashed {
           val extension = GetExtensionMIME(url.getPath(), r._2)
           (
             r._1.getCrawlDate,
+            CovertLastModifiedDate(r._1.getLastModified),
             r._1.getUrl,
             filename,
             extension,
@@ -679,10 +706,13 @@ package object archivesunleashed {
             encodedBytes
           )
         })
-        .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9))
+        .map(t =>
+          Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+        )
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -715,6 +745,7 @@ package object archivesunleashed {
           val extension = GetExtensionMIME(url.getPath(), r._2)
           (
             r._1.getCrawlDate,
+            CovertLastModifiedDate(r._1.getLastModified),
             r._1.getUrl,
             filename,
             extension,
@@ -725,10 +756,13 @@ package object archivesunleashed {
             RemoveHTTPHeader(r._1.getContentString)
           )
         })
-        .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9))
+        .map(t =>
+          Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+        )
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -761,6 +795,7 @@ package object archivesunleashed {
           val extension = GetExtensionMIME(url.getPath(), r._2)
           (
             r._1.getCrawlDate,
+            CovertLastModifiedDate(r._1.getLastModified),
             r._1.getUrl,
             filename,
             extension,
@@ -771,10 +806,13 @@ package object archivesunleashed {
             RemoveHTTPHeader(r._1.getContentString)
           )
         })
-        .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9))
+        .map(t =>
+          Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+        )
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -807,6 +845,7 @@ package object archivesunleashed {
           val extension = GetExtensionMIME(url.getPath(), r._2)
           (
             r._1.getCrawlDate,
+            CovertLastModifiedDate(r._1.getLastModified),
             r._1.getUrl,
             filename,
             extension,
@@ -817,10 +856,13 @@ package object archivesunleashed {
             RemoveHTTPHeader(r._1.getContentString)
           )
         })
-        .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9))
+        .map(t =>
+          Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+        )
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -853,6 +895,7 @@ package object archivesunleashed {
           val extension = GetExtensionMIME(url.getPath(), r._2)
           (
             r._1.getCrawlDate,
+            CovertLastModifiedDate(r._1.getLastModified),
             r._1.getUrl,
             filename,
             extension,
@@ -863,10 +906,13 @@ package object archivesunleashed {
             RemoveHTTPHeader(r._1.getContentString)
           )
         })
-        .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9))
+        .map(t =>
+          Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+        )
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -900,6 +946,7 @@ package object archivesunleashed {
           val extension = GetExtensionMIME(url.getPath(), r._2)
           (
             r._1.getCrawlDate,
+            CovertLastModifiedDate(r._1.getLastModified),
             r._1.getUrl,
             filename,
             extension,
@@ -910,10 +957,13 @@ package object archivesunleashed {
             RemoveHTTPHeader(r._1.getContentString)
           )
         })
-        .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9))
+        .map(t =>
+          Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+        )
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -946,6 +996,7 @@ package object archivesunleashed {
           val extension = GetExtensionMIME(url.getPath(), r._2)
           (
             r._1.getCrawlDate,
+            CovertLastModifiedDate(r._1.getLastModified),
             r._1.getUrl,
             filename,
             extension,
@@ -956,10 +1007,13 @@ package object archivesunleashed {
             RemoveHTTPHeader(r._1.getContentString)
           )
         })
-        .map(t => Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9))
+        .map(t =>
+          Row(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+        )
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
+        .add(StructField("last_modified", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))

--- a/src/main/scala/io/archivesunleashed/package.scala
+++ b/src/main/scala/io/archivesunleashed/package.scala
@@ -185,7 +185,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("domain", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("mime_type_web_server", StringType, true))
@@ -240,7 +240,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("domain", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("mime_type_web_server", StringType, true))
@@ -341,7 +341,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -393,7 +393,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -443,7 +443,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -493,7 +493,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -578,7 +578,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -643,7 +643,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -712,7 +712,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -762,7 +762,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -812,7 +812,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -862,7 +862,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -912,7 +912,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -963,7 +963,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))
@@ -1013,7 +1013,7 @@ package object archivesunleashed {
 
       val schema = new StructType()
         .add(StructField("crawl_date", StringType, true))
-        .add(StructField("last_modified", StringType, true))
+        .add(StructField("last_modified_date", StringType, true))
         .add(StructField("url", StringType, true))
         .add(StructField("filename", StringType, true))
         .add(StructField("extension", StringType, true))

--- a/src/test/scala/io/archivesunleashed/RecordDFTest.scala
+++ b/src/test/scala/io/archivesunleashed/RecordDFTest.scala
@@ -56,7 +56,7 @@ class RecordDFTest extends FunSuite with BeforeAndAfter {
   }
 
   test("Keep valid pages DF") {
-    val expected = "http://www.archive.org/"
+    val expected = "archive.org"
     val base = RecordLoader
       .loadArchives(arcPath, sc)
       .all()

--- a/src/test/scala/io/archivesunleashed/app/AudioInformationExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/AudioInformationExtractorTest.scala
@@ -46,13 +46,14 @@ class AudioInformationExtractorTest extends FunSuite with BeforeAndAfter {
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20190817230242")
-    assert(dfResults(0).get(1) == "https://ruebot.net/files/feniz.mp3")
-    assert(dfResults(0).get(2) == "feniz.mp3")
-    assert(dfResults(0).get(3) == "mp3")
-    assert(dfResults(0).get(4) == "audio/mpeg")
+    assert(dfResults(0).get(1) == "20111026005826")
+    assert(dfResults(0).get(2) == "https://ruebot.net/files/feniz.mp3")
+    assert(dfResults(0).get(3) == "feniz.mp3")
+    assert(dfResults(0).get(4) == "mp3")
     assert(dfResults(0).get(5) == "audio/mpeg")
-    assert(dfResults(0).get(6) == "f7e7ec84b12c294e19af1ba41732c733")
-    assert(dfResults(0).get(7) == "a3eb95dbbea76460529d0d9ebdde5faabaff544a")
+    assert(dfResults(0).get(6) == "audio/mpeg")
+    assert(dfResults(0).get(7) == "f7e7ec84b12c294e19af1ba41732c733")
+    assert(dfResults(0).get(8) == "a3eb95dbbea76460529d0d9ebdde5faabaff544a")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/CssInformationExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/CssInformationExtractorTest.scala
@@ -45,15 +45,16 @@ class CssInformationExtractorTest extends FunSuite with BeforeAndAfter {
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20080430204833")
+    assert(dfResults(0).get(1) == "20080422021044")
     assert(
-      dfResults(0).get(1) == "http://www.archive.org/stylesheets/details.css"
+      dfResults(0).get(2) == "http://www.archive.org/stylesheets/details.css"
     )
-    assert(dfResults(0).get(2) == "details.css")
-    assert(dfResults(0).get(3) == "css")
-    assert(dfResults(0).get(4) == "text/css")
-    assert(dfResults(0).get(5) == "text/plain")
-    assert(dfResults(0).get(6) == "f675020391de85d915a5ec65eb52e1c9")
-    assert(dfResults(0).get(7) == "2961a59b8fc20f401e1927dd0b63e5ae6e833f7a")
+    assert(dfResults(0).get(3) == "details.css")
+    assert(dfResults(0).get(4) == "css")
+    assert(dfResults(0).get(5) == "text/css")
+    assert(dfResults(0).get(6) == "text/plain")
+    assert(dfResults(0).get(7) == "f675020391de85d915a5ec65eb52e1c9")
+    assert(dfResults(0).get(8) == "2961a59b8fc20f401e1927dd0b63e5ae6e833f7a")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/HtmlInformationExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/HtmlInformationExtractorTest.scala
@@ -45,13 +45,14 @@ class HtmlInformationExtractorTest extends FunSuite with BeforeAndAfter {
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20080430204826")
-    assert(dfResults(0).get(1) == "http://www.archive.org/")
-    assert(dfResults(0).get(2) == "")
-    assert(dfResults(0).get(3) == "html")
-    assert(dfResults(0).get(4) == "text/html")
+    assert(dfResults(0).get(1) == "20080109231829")
+    assert(dfResults(0).get(2) == "http://www.archive.org/")
+    assert(dfResults(0).get(3) == "")
+    assert(dfResults(0).get(4) == "html")
     assert(dfResults(0).get(5) == "text/html")
-    assert(dfResults(0).get(6) == "990fc5f1674fd21b9a035cf9193c3f10")
-    assert(dfResults(0).get(7) == "d5817bf5b4b35a296823509dd754700a6ad522b5")
+    assert(dfResults(0).get(6) == "text/html")
+    assert(dfResults(0).get(7) == "990fc5f1674fd21b9a035cf9193c3f10")
+    assert(dfResults(0).get(8) == "d5817bf5b4b35a296823509dd754700a6ad522b5")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/ImageInformationExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/ImageInformationExtractorTest.scala
@@ -45,15 +45,16 @@ class ImageInformationExtractorTest extends FunSuite with BeforeAndAfter {
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20080430204829")
-    assert(dfResults(0).get(1) == "http://www.archive.org/images/logoc.jpg")
-    assert(dfResults(0).get(2) == "logoc.jpg")
-    assert(dfResults(0).get(3) == "jpg")
-    assert(dfResults(0).get(4) == "image/jpeg")
+    assert(dfResults(0).get(1) == "20030616222851")
+    assert(dfResults(0).get(2) == "http://www.archive.org/images/logoc.jpg")
+    assert(dfResults(0).get(3) == "logoc.jpg")
+    assert(dfResults(0).get(4) == "jpg")
     assert(dfResults(0).get(5) == "image/jpeg")
-    assert(dfResults(0).get(6) == 70)
-    assert(dfResults(0).get(7) == 56)
-    assert(dfResults(0).get(8) == "8211d1fbb9b03d8522a1ae378f9d1b24")
-    assert(dfResults(0).get(9) == "a671e68fc211ee4996a91e99297f246b2c5faa1a")
+    assert(dfResults(0).get(6) == "image/jpeg")
+    assert(dfResults(0).get(7) == 70)
+    assert(dfResults(0).get(8) == 56)
+    assert(dfResults(0).get(9) == "8211d1fbb9b03d8522a1ae378f9d1b24")
+    assert(dfResults(0).get(10) == "a671e68fc211ee4996a91e99297f246b2c5faa1a")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/JsInformationExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/JsInformationExtractorTest.scala
@@ -45,13 +45,14 @@ class JsInformationExtractorTest extends FunSuite with BeforeAndAfter {
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20080430204833")
-    assert(dfResults(0).get(1) == "http://www.archive.org/flv/flv.js?v=1.34")
-    assert(dfResults(0).get(2) == "flv.js")
-    assert(dfResults(0).get(3) == "js")
-    assert(dfResults(0).get(4) == "application/x-javascript")
-    assert(dfResults(0).get(5) == "text/plain")
-    assert(dfResults(0).get(6) == "8c73985a47e0d3720765d92fbde8cc9f")
-    assert(dfResults(0).get(7) == "83a0951127abb1da11b141ad22ac72c20f2b4804")
+    assert(dfResults(0).get(1) == "20080430064607")
+    assert(dfResults(0).get(2) == "http://www.archive.org/flv/flv.js?v=1.34")
+    assert(dfResults(0).get(3) == "flv.js")
+    assert(dfResults(0).get(4) == "js")
+    assert(dfResults(0).get(5) == "application/x-javascript")
+    assert(dfResults(0).get(6) == "text/plain")
+    assert(dfResults(0).get(7) == "8c73985a47e0d3720765d92fbde8cc9f")
+    assert(dfResults(0).get(8) == "83a0951127abb1da11b141ad22ac72c20f2b4804")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/JsonInfromationExtractor.scala
+++ b/src/test/scala/io/archivesunleashed/app/JsonInfromationExtractor.scala
@@ -46,16 +46,17 @@ class JsonInformationExtractorTest extends FunSuite with BeforeAndAfter {
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20190812222538")
+    assert(dfResults(0).get(1) == "")
     assert(
       dfResults(0)
-        .get(1) == "https://api.plu.mx/widget/other/artifact?type=doi&id=10.1109%2FJCDL.2019.00043&href=https%3A%2F%2Fplu.mx%2Fpitt%2Fa%2F%3Fdoi%3D10.1109%2FJCDL.2019.00043&ref=https%3A%2F%2Fyorkspace.library.yorku.ca%2Fxmlui%2Fhandle%2F10315%2F36158&pageToken=f74d46f3-f622-c670-e1bc-bdc3-aa500a283693&isElsWidget=false"
+        .get(2) == "https://api.plu.mx/widget/other/artifact?type=doi&id=10.1109%2FJCDL.2019.00043&href=https%3A%2F%2Fplu.mx%2Fpitt%2Fa%2F%3Fdoi%3D10.1109%2FJCDL.2019.00043&ref=https%3A%2F%2Fyorkspace.library.yorku.ca%2Fxmlui%2Fhandle%2F10315%2F36158&pageToken=f74d46f3-f622-c670-e1bc-bdc3-aa500a283693&isElsWidget=false"
     )
-    assert(dfResults(0).get(2) == "artifact")
-    assert(dfResults(0).get(3) == "json")
-    assert(dfResults(0).get(4) == "application/json")
-    assert(dfResults(0).get(5) == "N/A")
-    assert(dfResults(0).get(6) == "d41d8cd98f00b204e9800998ecf8427e")
-    assert(dfResults(0).get(7) == "da39a3ee5e6b4b0d3255bfef95601890afd80709")
+    assert(dfResults(0).get(3) == "artifact")
+    assert(dfResults(0).get(4) == "json")
+    assert(dfResults(0).get(5) == "application/json")
+    assert(dfResults(0).get(6) == "N/A")
+    assert(dfResults(0).get(7) == "d41d8cd98f00b204e9800998ecf8427e")
+    assert(dfResults(0).get(8) == "da39a3ee5e6b4b0d3255bfef95601890afd80709")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/PDFInformationExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/PDFInformationExtractorTest.scala
@@ -46,17 +46,18 @@ class PDFInformationExtractorTest extends FunSuite with BeforeAndAfter {
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20190812222529")
+    assert(dfResults(0).get(1) == "20190626132632")
     assert(
       dfResults(0).get(
-        1
+        2
       ) == "https://yorkspace.library.yorku.ca/xmlui/bitstream/handle/10315/36158/cost-analysis.pdf?sequence=1&isAllowed=y"
     )
-    assert(dfResults(0).get(2) == "cost-analysis.pdf")
-    assert(dfResults(0).get(3) == "pdf")
-    assert(dfResults(0).get(4) == "application/pdf")
+    assert(dfResults(0).get(3) == "cost-analysis.pdf")
+    assert(dfResults(0).get(4) == "pdf")
     assert(dfResults(0).get(5) == "application/pdf")
-    assert(dfResults(0).get(6) == "aaba59d2287afd40c996488a39bbc0dd")
-    assert(dfResults(0).get(7) == "569c28e0e8faa6945d6ca88fcd9e195825052c71")
+    assert(dfResults(0).get(6) == "application/pdf")
+    assert(dfResults(0).get(7) == "aaba59d2287afd40c996488a39bbc0dd")
+    assert(dfResults(0).get(8) == "569c28e0e8faa6945d6ca88fcd9e195825052c71")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/PlainTextInformationExtractor.scala
+++ b/src/test/scala/io/archivesunleashed/app/PlainTextInformationExtractor.scala
@@ -45,13 +45,14 @@ class PlainTextInformationExtractorTest extends FunSuite with BeforeAndAfter {
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20080430204825")
-    assert(dfResults(0).get(1) == "http://www.archive.org/robots.txt")
-    assert(dfResults(0).get(2) == "robots.txt")
-    assert(dfResults(0).get(3) == "txt")
-    assert(dfResults(0).get(4) == "text/plain")
+    assert(dfResults(0).get(1) == "20080202194044")
+    assert(dfResults(0).get(2) == "http://www.archive.org/robots.txt")
+    assert(dfResults(0).get(3) == "robots.txt")
+    assert(dfResults(0).get(4) == "txt")
     assert(dfResults(0).get(5) == "text/plain")
-    assert(dfResults(0).get(6) == "a6d6869f680b1bdd0d27bf5a5f49482e")
-    assert(dfResults(0).get(7) == "95046652b71aaa1e8a5a6af91e24016dfeae7bd4")
+    assert(dfResults(0).get(6) == "text/plain")
+    assert(dfResults(0).get(7) == "a6d6869f680b1bdd0d27bf5a5f49482e")
+    assert(dfResults(0).get(8) == "95046652b71aaa1e8a5a6af91e24016dfeae7bd4")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/PresentationProgramInformationExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/PresentationProgramInformationExtractorTest.scala
@@ -48,25 +48,26 @@ class PresentationProgramInformationExtractorTest
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20190815004338")
+    assert(dfResults(0).get(1) == "20190814234811")
     assert(
       dfResults(0).get(
-        1
+        2
       ) == "https://ruebot.net/files/aut-test-fixtures/aut-test-fixtures.pptx"
     )
-    assert(dfResults(0).get(2) == "aut-test-fixtures.pptx")
-    assert(dfResults(0).get(3) == "pptx")
-    assert(
-      dfResults(0).get(
-        4
-      ) == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-    )
+    assert(dfResults(0).get(3) == "aut-test-fixtures.pptx")
+    assert(dfResults(0).get(4) == "pptx")
     assert(
       dfResults(0).get(
         5
       ) == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
     )
-    assert(dfResults(0).get(6) == "7a7b1fe4b6d311376eaced9de3b682ee")
-    assert(dfResults(0).get(7) == "86fadca47b134b68247ccde62da4ce3f62b4d2ec")
+    assert(
+      dfResults(0).get(
+        6
+      ) == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    )
+    assert(dfResults(0).get(7) == "7a7b1fe4b6d311376eaced9de3b682ee")
+    assert(dfResults(0).get(8) == "86fadca47b134b68247ccde62da4ce3f62b4d2ec")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/SpreadsheetInformationExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/SpreadsheetInformationExtractorTest.scala
@@ -46,21 +46,22 @@ class SpreadsheetInformationExtractorTest extends FunSuite with BeforeAndAfter {
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20190815004345")
+    assert(dfResults(0).get(1) == "20190814234730")
     assert(
       dfResults(0).get(
-        1
+        2
       ) == "https://ruebot.net/files/aut-test-fixtures/test-aut-fixture.ods"
     )
-    assert(dfResults(0).get(2) == "test-aut-fixture.ods")
-    assert(dfResults(0).get(3) == "ods")
-    assert(
-      dfResults(0).get(4) == "application/vnd.oasis.opendocument.spreadsheet"
-    )
+    assert(dfResults(0).get(3) == "test-aut-fixture.ods")
+    assert(dfResults(0).get(4) == "ods")
     assert(
       dfResults(0).get(5) == "application/vnd.oasis.opendocument.spreadsheet"
     )
-    assert(dfResults(0).get(6) == "7f70280757d8beb2d1bfd6fb1b6ae6e9")
-    assert(dfResults(0).get(7) == "448c357e78317877a98a399448031a89f1dda6fb")
+    assert(
+      dfResults(0).get(6) == "application/vnd.oasis.opendocument.spreadsheet"
+    )
+    assert(dfResults(0).get(7) == "7f70280757d8beb2d1bfd6fb1b6ae6e9")
+    assert(dfResults(0).get(8) == "448c357e78317877a98a399448031a89f1dda6fb")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/VideoInformationExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/VideoInformationExtractorTest.scala
@@ -46,15 +46,16 @@ class VideoInformationExtractorTest extends FunSuite with BeforeAndAfter {
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20190817230310")
+    assert(dfResults(0).get(1) == "20190812230929")
     assert(
-      dfResults(0).get(1) == "https://ruebot.net/2018-11-12%2016.14.11.mp4"
+      dfResults(0).get(2) == "https://ruebot.net/2018-11-12%2016.14.11.mp4"
     )
-    assert(dfResults(0).get(2) == "2018-11-12%2016.14.11.mp4")
-    assert(dfResults(0).get(3) == "mp4")
-    assert(dfResults(0).get(4) == "video/mp4")
+    assert(dfResults(0).get(3) == "2018-11-12%2016.14.11.mp4")
+    assert(dfResults(0).get(4) == "mp4")
     assert(dfResults(0).get(5) == "video/mp4")
-    assert(dfResults(0).get(6) == "2cde7de3213a87269957033f6315fce2")
-    assert(dfResults(0).get(7) == "f28c72fa4c0464a1a2b81fdc539b28cf574ac4c2")
+    assert(dfResults(0).get(6) == "video/mp4")
+    assert(dfResults(0).get(7) == "2cde7de3213a87269957033f6315fce2")
+    assert(dfResults(0).get(8) == "f28c72fa4c0464a1a2b81fdc539b28cf574ac4c2")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/WebPagesExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/WebPagesExtractorTest.scala
@@ -45,11 +45,12 @@ class WebPagesExtractorTest extends FunSuite with BeforeAndAfter {
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20080430204826")
-    assert(dfResults(0).get(1) == "archive.org")
-    assert(dfResults(0).get(2) == "http://www.archive.org/")
-    assert(dfResults(0).get(3) == "text/html")
+    assert(dfResults(0).get(1) == "20080109231829")
+    assert(dfResults(0).get(2) == "archive.org")
+    assert(dfResults(0).get(3) == "http://www.archive.org/")
     assert(dfResults(0).get(4) == "text/html")
-    assert(dfResults(0).get(5) == "en")
+    assert(dfResults(0).get(5) == "text/html")
+    assert(dfResults(0).get(6) == "en")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/WordProcessorInformationExtractorTest.scala
+++ b/src/test/scala/io/archivesunleashed/app/WordProcessorInformationExtractorTest.scala
@@ -48,17 +48,18 @@ class WordProcessorInformationExtractorTest
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20190815004423")
+    assert(dfResults(0).get(1) == "20190814234647")
     assert(
       dfResults(0).get(
-        1
+        2
       ) == "https://ruebot.net/files/aut-test-fixtures/test-aut-fixtures.rtf"
     )
-    assert(dfResults(0).get(2) == "test-aut-fixtures.rtf")
-    assert(dfResults(0).get(3) == "rtf")
-    assert(dfResults(0).get(4) == "application/rtf")
+    assert(dfResults(0).get(3) == "test-aut-fixtures.rtf")
+    assert(dfResults(0).get(4) == "rtf")
     assert(dfResults(0).get(5) == "application/rtf")
-    assert(dfResults(0).get(6) == "e483512b65ba44d71e843c57de2adeb7")
-    assert(dfResults(0).get(7) == "8cf3066421f0a07fcd6e7a3e86ebd447edf7cfcb")
+    assert(dfResults(0).get(6) == "application/rtf")
+    assert(dfResults(0).get(7) == "e483512b65ba44d71e843c57de2adeb7")
+    assert(dfResults(0).get(8) == "8cf3066421f0a07fcd6e7a3e86ebd447edf7cfcb")
   }
 
   after {

--- a/src/test/scala/io/archivesunleashed/app/XmlInfromationExtractor.scala
+++ b/src/test/scala/io/archivesunleashed/app/XmlInfromationExtractor.scala
@@ -45,16 +45,17 @@ class XmlInformationExtractorTest extends FunSuite with BeforeAndAfter {
 
     assert(dfResults.length == RESULTSLENGTH)
     assert(dfResults(0).get(0) == "20080430204830")
+    assert(dfResults(0).get(1) == "")
     assert(
       dfResults(0)
-        .get(1) == "http://www.archive.org/services/collection-rss.php"
+        .get(2) == "http://www.archive.org/services/collection-rss.php"
     )
-    assert(dfResults(0).get(2) == "collection-rss.php")
-    assert(dfResults(0).get(3) == "xml")
-    assert(dfResults(0).get(4) == "text/xml")
-    assert(dfResults(0).get(5) == "application/rss+xml")
-    assert(dfResults(0).get(6) == "647a665e6acc2141af6d377b02e16c99")
-    assert(dfResults(0).get(7) == "4dee969d37e188ce705c6b99b8a6ca62aa1418e5")
+    assert(dfResults(0).get(3) == "collection-rss.php")
+    assert(dfResults(0).get(4) == "xml")
+    assert(dfResults(0).get(5) == "text/xml")
+    assert(dfResults(0).get(6) == "application/rss+xml")
+    assert(dfResults(0).get(7) == "647a665e6acc2141af6d377b02e16c99")
+    assert(dfResults(0).get(8) == "4dee969d37e188ce705c6b99b8a6ca62aa1418e5")
   }
 
   after {


### PR DESCRIPTION
**GitHub issue(s)**: #546

# What does this Pull Request do?

Implements extracting `last_modified_date` of a resource where available.

* Adds `getLastModified` for `SparklingArchiveRecord`
* Adds `CovertLastModifiedDate` to convert RFC 1123 dates to `yyyyMMddHHmmss`
  * See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified
* Implement `last_modified_date` column for
  * `.all()`
  * `.webpages()`
  * `.images()`
  * `.pdfs()`
  * `.audio()`
  * `.videos()`
  * `.spreadsheets()`
  * `.presentationProgramFiles()`
  * `.wordProcessorFiles()`
  * `.css()`
  * `.html()`
  * `.js()`
  * `.json()`
  * `.plainText()`
  * `.xml()`
* Update tests
* Resolves #546

Example:

```
import io.archivesunleashed._
val data = "/home/nruest/Projects/au/sample-data/geocities/GEOCITIES-20091027143300-00114-ia400112.us.archive.org.warc.gz"
RecordLoader.loadArchives(data, sc).all().select($"crawl_date", $"last_modified_date").show(20, false)

// Exiting paste mode, now interpreting.

[2022-11-02T16:05:35.325Z - 00000 - HdfsIO] Opening file file:/home/nruest/Projects/au/sample-data/geocities/GEOCITIES-20091027143300-00114-ia400112.us.archive.org.warc.gz (Offset: 0, length: 0, decompress: false, strategy: BlockWise [dynamic])
+--------------+------------------+                                             
|crawl_date    |last_modified_date|
+--------------+------------------+
|20091027143300|                  |
|20091027143259|20000923233454    |
|20091027143259|20020913163029    |
|20091027143300|20020211154553    |
|20091027143259|19980919164703    |
|20091027143259|20080125150303    |
|20091027143300|20010921224658    |
|20091027143258|20081009015203    |
|20091027143300|                  |
|20091027143259|20020416145103    |
|20091027143300|20090223022835    |
|20091027143300|20030928090558    |
|20091027143300|20091027143300    |
|20091027143300|20021203212451    |
|20091027143300|                  |
|20091027143300|20040530033010    |
|20091027143300|                  |
|20091027143259|20090223022352    |
|20091027143300|                  |
|20091027143300|20010608202736    |
+--------------+------------------+
only showing top 20 rows

import io.archivesunleashed._
data: String = /home/nruest/Projects/au/sample-data/geocities/GEOCITIES-20091027143300-00114-ia400112.us.archive.org.warc.gz
```

# How should this be tested?

* Tests should take care of it.
* I'm also going to test this at scale with the GeoCities dataset.

# Additional Notes:

This is going to require *A LOT* of documentation updates.

# Interested parties

@digitalshawn :wave: 